### PR TITLE
direnv: fix fish init

### DIFF
--- a/direnv/nixos.nix
+++ b/direnv/nixos.nix
@@ -31,7 +31,7 @@ in {
       eval "$(${pkgs.direnv}/bin/direnv hook zsh)"
     '';
     fish.interactiveShellInit = ''
-      eval "$(${pkgs.direnv}/bin/direnv hook fish)"
+      eval (${pkgs.direnv}/bin/direnv hook fish)
     '';
   };
 }


### PR DESCRIPTION
Fish does not support `$(...)` command substitution at the moment.