### PR TITLE
Cargo plugins

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,5 @@
+# pick up cargo plugins
+PATH_add ./.cargo/bin
 
 if [ -e ./target/debug/lorri ]; then
     echo "direnv: using local lorri (./target/debug/lorri)"

--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,9 @@
 # pick up cargo plugins
 PATH_add ./.cargo/bin
 
+# watch the output to add lorri once it’s built
+PATH_add ./target/debug
+
 if [ -e ./target/debug/lorri ]; then
     echo "direnv: using local lorri (./target/debug/lorri)"
     eval "$(./target/debug/lorri direnv)"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
+# `cargo build` dir
 /target
+# we set this as CARGO_INSTALL_ROOT
+/.cargo
+# lorri cache dir
+.lorri
+# nix-build symlink
+result
 **/*.rs.bk
 .bash_history
-.lorri
-result

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,5 @@
 { pkgs ? import ./nix/nixpkgs.nix { enableMozillaOverlay = true; } }:
-pkgs.mkShell {
+pkgs.mkShell rec {
   name = "lorri";
   buildInputs = [
     # This rust comes from the Mozilla rust overlay so we can
@@ -17,13 +17,21 @@ pkgs.mkShell {
 
   # Keep project-specific shell commands local
   HISTFILE = "${toString ./.}/.bash_history";
-  # Enable printing backtraces for rust binaries
-  RUST_BACKTRACE = 1;
+
+  # Lorri-specific
+
   # The root directory of this project
   LORRI_ROOT = toString ./.;
   # Needed by the lorri build.rs to determine its own version
   # for the development repository (non-release), we set it to 1
   BUILD_REV_COUNT = 1;
+
+  # Rust-specific
+
+  # Enable printing backtraces for rust binaries
+  RUST_BACKTRACE = 1;
+  # Set up a local directory to install binaries in
+  CARGO_INSTALL_ROOT = "${LORRI_ROOT}/.cargo";
 
   # Executed when entering `nix-shell`
   shellHook = ''

--- a/shell.nix
+++ b/shell.nix
@@ -100,4 +100,7 @@ pkgs.mkShell rec {
     # Cargo wasn't able to find CF during a `cargo test` run on Darwin.
     export NIX_LDFLAGS="-F${pkgs.darwin.apple_sdk.frameworks.CoreFoundation}/Library/Frameworks -framework CoreFoundation $NIX_LDFLAGS"
   '');
+
+  preferLocalBuild = true;
+  buildUseSubstitutes = false;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -49,6 +49,12 @@ pkgs.mkShell rec {
     alias newlorri="(cd $LORRI_ROOT; cargo run -- shell)"
     alias ci="ci_check"
 
+    # this is mirrored from .envrc to make available from nix-shell
+    # pick up cargo plugins
+    export PATH="$LORRI_ROOT/.cargo/bin:$PATH"
+    # watch the output to add lorri once it's built
+    export PATH="$LORRI_ROOT/target/debug:$PATH"
+
     function ci_check() (
       cd "$LORRI_ROOT";
 

--- a/shell.nix
+++ b/shell.nix
@@ -14,11 +14,18 @@ pkgs.mkShell {
     pkgs.darwin.apple_sdk.frameworks.CoreServices
     pkgs.darwin.apple_sdk.frameworks.CoreFoundation
   ];
+
   # Keep project-specific shell commands local
   HISTFILE = "${toString ./.}/.bash_history";
+  # Enable printing backtraces for rust binaries
   RUST_BACKTRACE = 1;
+  # The root directory of this project
   ROOT = toString ./.;
+  # Needed by the lorri build.rs to determine its own version
+  # for the development repository (non-release), we set it to 1
   BUILD_REV_COUNT = 1;
+
+  # Executed when entering `nix-shell`
   shellHook = ''
     # we can only output to stderr in the shellHook,
     # otherwise direnv `use nix` does not work.

--- a/shell.nix
+++ b/shell.nix
@@ -20,7 +20,7 @@ pkgs.mkShell {
   # Enable printing backtraces for rust binaries
   RUST_BACKTRACE = 1;
   # The root directory of this project
-  ROOT = toString ./.;
+  LORRI_ROOT = toString ./.;
   # Needed by the lorri build.rs to determine its own version
   # for the development repository (non-release), we set it to 1
   BUILD_REV_COUNT = 1;
@@ -38,11 +38,11 @@ pkgs.mkShell {
     # nix-shell, you don't need this.
     export SHELL="${pkgs.bashInteractive}/bin/bash";
 
-    alias newlorri="(cd $ROOT; cargo run -- shell)"
+    alias newlorri="(cd $LORRI_ROOT; cargo run -- shell)"
     alias ci="ci_check"
 
     function ci_check() (
-      cd "$ROOT";
+      cd "$LORRI_ROOT";
 
       set -x
 


### PR DESCRIPTION
*This PR was missed in the migration, already merged in the original repository*

This is the first work on integrating cargo plugins.

It mostly sets CARGO_INSTALL_ROOT to the project directory, so cargo install <plugin> will be put in ./.cargo/bin, which is also added to the direnv PATH.