### PR TITLE
nix/nixpkgs.nix: default `enableMozillaOverlay` to `false`.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 {
-  pkgs ? import ./nix/nixpkgs.nix { enableMozillaOverlay = false; },
+  pkgs ? import ./nix/nixpkgs.nix { },
   src ? builtins.fetchGit {
     url = ./.;
     ref = "HEAD";

--- a/example/shell.nix
+++ b/example/shell.nix
@@ -1,4 +1,4 @@
-with import ../nix/nixpkgs.nix { enableMozillaOverlay = false; };
+with import ../nix/nixpkgs.nix { };
 
 mkShell {
   buildInputs = [

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,4 +1,4 @@
-{ enableMozillaOverlay }:
+{ enableMozillaOverlay ? false }:
 let
   hostpkgs = import <nixpkgs> {};
 


### PR DESCRIPTION
We only need to enable the Overlay for rust nightly, which we only use
in our dev-shell for lorri. In all other places we don’t need it.

Having no default value also broke the tutorial (direnv setup),
because `nix-env -f ./nix/nixpkgs.nix` would not work anymore.