### PR TITLE
Default enableMozillaOverlay to false

### DIFF
--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,4 +1,4 @@
-{ enableMozillaOverlay }:
+{ enableMozillaOverlay ? false }:
 let
   hostpkgs = import <nixpkgs> {};
 


### PR DESCRIPTION
When following the tutorial's instructions for installing direnv from the overlay, I got this error:

```
$ nix-env -f ../nix/nixpkgs.nix -i -A direnv
error: cannot auto-call a function that has an argument without a default value ('enableMozillaOverlay')
```

I added a default value so that the command would work. If this is not preferred, I'd recommend updating the installation instructions.