### PR TITLE
direnv: print error if lorri watch has not been run

### DIFF
--- a/src/ops/direnv/mod.rs
+++ b/src/ops/direnv/mod.rs
@@ -15,6 +15,10 @@ pub fn main(project: Project) -> OpResult {
     let mut shell_root = project.gc_root_path().unwrap();
     shell_root.push("build-0"); // !!!
 
+    if !shell_root.exists() {
+        return ExitError::errmsg("Please run 'lorri watch' before using direnv integration.");
+    }
+
     println!(
         r#"
 EVALUATION_ROOT="{}"


### PR DESCRIPTION
Closes #9, though we should make a new issue to have it auto-evaluate the first time.