### PR TITLE
Create nix per-user gcroot directory if missing

### DIFF
--- a/src/build_loop.rs
+++ b/src/build_loop.rs
@@ -78,6 +78,10 @@ impl BuildLoop {
                 Ok(())
             };
             match go() {
+                // TODO: Make err use Display instead of Debug.
+                // Otherwise user errors (especially for IO errors)
+                // are pretty hard to debug. Might need to review
+                // whether we can handle some errors earlier than here.
                 Err(err) => panic!("{}: {:?}", "Builder failed", err),
                 Ok(()) => {}
             }

--- a/src/roots.rs
+++ b/src/roots.rs
@@ -25,8 +25,19 @@ impl Roots {
         path.push(name);
 
         debug!("Adding root from {:?} to {:?}", store_path, path,);
-        ignore_missing(std::fs::remove_file(&path))?;
-        symlink(&store_path, &path)?;
+        check_permission(
+            ignore_missing(std::fs::remove_file(&path)),
+            &format!("Can’t remove {}", path.display()),
+        )?;
+
+        check_permission(
+            symlink(&store_path, &path),
+            &format!(
+                "Can’t symlink {} to {}",
+                store_path.display(),
+                path.display()
+            ),
+        )?;
 
         // this is bad.
         let mut root = PathBuf::from("/nix/var/nix/gcroots/per-user");
@@ -40,8 +51,14 @@ impl Roots {
         root.push(format!("{}-{}", self.id, name));
 
         debug!("Connecting root from {:?} to {:?}", path, root,);
-        ignore_missing(std::fs::remove_file(&root))?;
-        symlink(&path, &root)?;
+        check_permission(
+            ignore_missing(std::fs::remove_file(&root)),
+            &format!("Can’t remove {}", root.display()),
+        )?;
+        check_permission(
+            symlink(&path, &root),
+            &format!("Can’t symlink {} to {}", path.display(), root.display()),
+        )?;
 
         Ok(path)
     }
@@ -70,15 +87,22 @@ fn ensure_directory_exists(dir: &PathBuf) {
     }
 }
 
-fn ignore_missing(err: Result<(), std::io::Error>) -> Result<(), std::io::Error> {
-    if let Err(e) = err {
-        match e.kind() {
-            std::io::ErrorKind::NotFound => Ok(()),
-            _ => Err(e),
+/// Ignore a `NotFound` error.
+fn ignore_missing(err: std::io::Result<()>) -> std::io::Result<()> {
+    err.or_else(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => Ok(()),
+        _ => Err(e),
+    })
+}
+
+/// Take a result and panic if there was a `PermissionDenied` error.
+fn check_permission(err: std::io::Result<()>, permission_errormsg: &str) -> std::io::Result<()> {
+    err.or_else(|e| match e.kind() {
+        std::io::ErrorKind::PermissionDenied => {
+            panic!(format!("Permission denied. {}", permission_errormsg))
         }
-    } else {
-        Ok(())
-    }
+        _ => Err(e),
+    })
 }
 
 /// Error conditions encountered when adding roots

--- a/src/roots.rs
+++ b/src/roots.rs
@@ -30,7 +30,13 @@ impl Roots {
 
         // this is bad.
         let mut root = PathBuf::from("/nix/var/nix/gcroots/per-user");
+        // TODO: check on start
         root.push(env::var("USER").expect("env var 'USER' must be set"));
+
+        // The user directory sometimes doesn’t exist,
+        // but we can create it (it’s root but `rwxrwxrwx`)
+        ensure_directory_exists(&root);
+
         root.push(format!("{}-{}", self.id, name));
 
         debug!("Connecting root from {:?} to {:?}", path, root,);
@@ -38,6 +44,29 @@ impl Roots {
         symlink(&path, &root)?;
 
         Ok(path)
+    }
+}
+
+/// Check if a directory exists and is a directory.
+/// Try to create it if nothing’s there.
+/// Panic for everything else.
+fn ensure_directory_exists(dir: &PathBuf) {
+    match std::fs::metadata(dir) {
+        Err(e) => {
+            if let std::io::ErrorKind::NotFound = e.kind() {
+                std::fs::create_dir(dir).unwrap_or_else(|_| {
+                    panic!(
+                        "directory {} does not exist and we can’t create it",
+                        dir.display()
+                    )
+                })
+            }
+        }
+        Ok(meta) => {
+            if !meta.is_dir() {
+                panic!("{} is not a directory", dir.display())
+            }
+        }
     }
 }
 
@@ -57,9 +86,6 @@ fn ignore_missing(err: Result<(), std::io::Error>) -> Result<(), std::io::Error>
 pub enum AddRootError {
     /// IO-related errors
     Io(std::io::Error),
-
-    /// Execution time errors
-    FailureToAdd,
 }
 
 impl From<std::io::Error> for AddRootError {


### PR DESCRIPTION
See commit messages. I also improved the error messages for permission errors.
It would be nice to have an integration test (which has to be sandboxed), I just tested it manually for now, but I think it’s fine.