### PR TITLE
Improve build loop

### DIFF
--- a/src/build_loop.rs
+++ b/src/build_loop.rs
@@ -89,7 +89,11 @@ impl BuildLoop {
         }
     }
 
-    fn once(&mut self) -> Result<BuildResults, BuildError> {
+    /// Execute a single build of the environment.
+    ///
+    /// This will create GC roots and expand the file watch list for
+    /// the evaluation.
+    pub fn once(&mut self) -> Result<BuildResults, BuildError> {
         let build = builder::run(&self.nix_root_path)?;
 
         let paths = build.paths;
@@ -130,14 +134,30 @@ impl BuildLoop {
     }
 }
 
+/// Error classes returnable from a build.
+///
+/// Callers should probably exit on Unrecoverable errors, but retry
+/// with Recoverable errors.
 #[derive(Debug)]
-enum BuildError {
+pub enum BuildError {
+    /// Recoverable errors are caused by failures to evaluate or build
+    /// the Nix expression itself.
     Recoverable(BuildExitFailure),
+
+    /// Unrecoverable errors are anything else: a broken Nix,
+    /// permission problems, etc.
     Unrecoverable(UnrecoverableErrors),
 }
 
+/// Unrecoverable errors due to internal failures of the plumbing.
+/// For example `exec` failing, permissions problems, kernel faults,
+/// etc.
+///
+/// See the corresponding Error struct documentation for further
+/// information.
 #[derive(Debug)]
-enum UnrecoverableErrors {
+#[allow(missing_docs)]
+pub enum UnrecoverableErrors {
     Build(builder::Error),
     AddRoot(roots::AddRootError),
     Notify(notify::Error),

--- a/src/build_loop.rs
+++ b/src/build_loop.rs
@@ -72,6 +72,7 @@ impl BuildLoop {
     pub fn forever(&mut self) {
         loop {
             let mut go = || -> Result<(), SingleBuildError> {
+                self.tx.send(Event::Started)?;
                 let event = self.once()?;
                 self.tx.send(event)?;
                 self.watch.wait_for_change().expect("Waiter exited");
@@ -85,7 +86,6 @@ impl BuildLoop {
     }
 
     fn once(&mut self) -> Result<Event, SingleBuildError> {
-        self.tx.send(Event::Started)?;
         let build = builder::run(&self.nix_root_path)?;
 
         let paths = build.paths;

--- a/src/ops/shell.rs
+++ b/src/ops/shell.rs
@@ -84,8 +84,8 @@ pub fn main(project: Project) -> OpResult {
         .status()
         .expect("Failed to execute bash");
 
-    build_thread.join().unwrap();
-    msg_handler_thread.join().unwrap();
+    drop(build_thread);
+    drop(msg_handler_thread);
 
     Ok(())
 }

--- a/src/ops/shell.rs
+++ b/src/ops/shell.rs
@@ -15,11 +15,11 @@ pub fn main(project: Project) -> OpResult {
     let (tx, rx) = channel();
     let root_nix_file = &project.expression();
     let roots = Roots::new(project.gc_root_path().unwrap(), project.id());
-    let mut build_loop = BuildLoop::new(root_nix_file.clone(), roots.clone(), tx);
+    let mut build_loop = BuildLoop::new(root_nix_file.clone(), roots.clone());
 
     let build_thread = {
         thread::spawn(move || {
-            build_loop.forever();
+            build_loop.forever(tx);
         })
     };
 

--- a/src/ops/watch.rs
+++ b/src/ops/watch.rs
@@ -13,11 +13,11 @@ pub fn main(project: &Project) -> OpResult {
     let (tx, rx) = channel();
     let roots = Roots::new(project.gc_root_path().unwrap(), project.id());
 
-    let mut build_loop = BuildLoop::new(project.expression(), roots, tx);
+    let mut build_loop = BuildLoop::new(project.expression(), roots);
 
     let build_thread = {
         thread::spawn(move || {
-            build_loop.forever();
+            build_loop.forever(tx);
         })
     };
 


### PR DESCRIPTION
As part of researching, experimenting with, and testing for bug #23, I've made some improvements to BuildLoop. Definitely go commit-by-commit, but the end result means BuildLoop is much more ergonomic:

 - you don't have to use a mpsc channel to use BuildLoop
 - you don't have to use a thread to use BuildLoop
 an OK(...) from `once()` means it worked fine, and an Err means it didn't (before we could return a `Ok(Failure(...))` which is pretty weird

and finally:
 
 - `lorri shell`'s code is nicer, since we don't need to wait for just the first message from the RX
 - exiting the shell inside `lorri shell` actually exits
