### PR TITLE
Make 'enable direnv' step more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ $ curl -o direnv.nix -L https://github.com/target/lorri/raw/master/direnv/nix.ni
 $ nix-env -if ./direnv.nix
 ```
 
-then enable it according to [direnv's setup instructions][direnv-setup].
+### Enable direnv
+
+Enable direnv according to [its setup instructions][direnv-setup].
 
 ### Installing lorri
 


### PR DESCRIPTION
I got stuck on direnv magically not seeming to do anything after setting everything up. It took me a while to realize that I missed the "enable direnv according to its instructions" step (assuming that the Nix expression would do that for me), as it was a relatively unnoticeable footnote.

This PR changes that, by making enabling it a clear and discrete step in the setup process.