### PR TITLE
Implement "init" command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,6 +45,10 @@ pub enum Command {
     /// Upgrade Lorri
     #[structopt(name = "self-upgrade", alias = "self-update")]
     Upgrade(UpgradeTo),
+
+    /// Bootstrap files for a new setup
+    #[structopt(name = "init")]
+    Init,
 }
 
 /// A stub struct to represent how what we want to upgrade to.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,13 @@ extern crate structopt;
 extern crate log;
 
 use lorri::cli::{Arguments, Command};
-use lorri::ops::{build, direnv, info, shell, upgrade, watch, ExitError, OpResult};
+use lorri::ops::{build, direnv, info, init, shell, upgrade, watch, ExitError, OpResult};
 use lorri::project::{Project, ProjectLoadError};
 use std::env;
 use structopt::StructOpt;
 
 const TRIVIAL_SHELL_SRC: &str = include_str!("./trivial-shell.nix");
+const DEFAULT_ENVRC: &str = "eval \"$(lorri direnv)\"";
 
 fn main() {
     let opts = Arguments::from_args();
@@ -31,6 +32,8 @@ fn main() {
         (Command::Watch, Ok(project)) => watch::main(&project),
 
         (Command::Upgrade(args), _) => upgrade::main(args),
+
+        (Command::Init, _) => init::main(TRIVIAL_SHELL_SRC, DEFAULT_ENVRC),
 
         (_, Err(ProjectLoadError::ConfigNotFound)) => {
             let current_dir_msg = match env::current_dir() {

--- a/src/ops/init/mod.rs
+++ b/src/ops/init/mod.rs
@@ -1,6 +1,6 @@
 //! Bootstrap a new lorri project
 
-use crate::ops::{ok, ExitError, OpResult};
+use crate::ops::{ok, ok_msg, ExitError, OpResult};
 use std::fs::File;
 use std::io;
 use std::io::Write;
@@ -33,5 +33,5 @@ pub fn main(default_shell: &str, default_envrc: &str) -> OpResult {
     to_op(create_if_missing(Path::new("./shell.nix"), default_shell))?;
     to_op(create_if_missing(Path::new("./.envrc"), default_envrc))?;
 
-    Ok(Some(String::from("\nSetup done.")))
+    ok_msg(String::from("\nSetup done."))
 }

--- a/src/ops/init/mod.rs
+++ b/src/ops/init/mod.rs
@@ -6,9 +6,9 @@ use std::io;
 use std::io::Write;
 use std::path::Path;
 
-fn create_if_missing(path: &Path, contents: &str) -> Result<(), io::Error> {
+fn create_if_missing(path: &Path, contents: &str, msg: &str) -> Result<(), io::Error> {
     if path.exists() {
-        println!("- Skipping existing {}", path.display());
+        println!("- {} {}", msg, path.display());
         Ok(())
     } else {
         let mut f = File::create(path)?;
@@ -28,8 +28,17 @@ fn to_op(e: Result<(), io::Error>) -> OpResult {
 /// See the documentation for lorri::cli::Command::Init for
 /// more details
 pub fn main(default_shell: &str, default_envrc: &str) -> OpResult {
-    to_op(create_if_missing(Path::new("./shell.nix"), default_shell))?;
-    to_op(create_if_missing(Path::new("./.envrc"), default_envrc))?;
+    to_op(create_if_missing(
+        Path::new("./shell.nix"),
+        default_shell,
+        "shell.nix exists, skipping. Make sure it is of a form that works with nix-shell.",
+    ))?;
+
+    to_op(create_if_missing(
+        Path::new("./.envrc"), 
+        default_envrc,
+        ".envrc exists, skipping. Please add 'eval \"$(lorri direnv)\" to it to set up lorri support.",
+    ))?;
 
     ok_msg(String::from("\nSetup done."))
 }

--- a/src/ops/init/mod.rs
+++ b/src/ops/init/mod.rs
@@ -28,8 +28,6 @@ fn to_op(e: Result<(), io::Error>) -> OpResult {
 /// See the documentation for lorri::cli::Command::Init for
 /// more details
 pub fn main(default_shell: &str, default_envrc: &str) -> OpResult {
-    println!("Bootstrapping a new lorri project\n");
-
     to_op(create_if_missing(Path::new("./shell.nix"), default_shell))?;
     to_op(create_if_missing(Path::new("./.envrc"), default_envrc))?;
 

--- a/src/ops/init/mod.rs
+++ b/src/ops/init/mod.rs
@@ -1,0 +1,37 @@
+//! Bootstrap a new lorri project
+
+use crate::ops::{ok, ExitError, OpResult};
+use std::fs::File;
+use std::io;
+use std::io::Write;
+use std::path::Path;
+
+fn create_if_missing(path: &Path, contents: &str) -> Result<(), io::Error> {
+    if path.exists() {
+        println!("- Skipping existing {}", path.display());
+        Ok(())
+    } else {
+        let mut f = File::create(path)?;
+        f.write_all(contents.as_bytes())?;
+        println!("- Writing {}", path.display());
+        Ok(())
+    }
+}
+
+fn to_op(e: Result<(), io::Error>) -> OpResult {
+    match e {
+        Ok(_) => ok(),
+        Err(e) => ExitError::errmsg(format!("{}", e)),
+    }
+}
+
+/// See the documentation for lorri::cli::Command::Init for
+/// more details
+pub fn main(default_shell: &str, default_envrc: &str) -> OpResult {
+    println!("Bootstrapping a new lorri project\n");
+
+    to_op(create_if_missing(Path::new("./shell.nix"), default_shell))?;
+    to_op(create_if_missing(Path::new("./.envrc"), default_envrc))?;
+
+    Ok(Some(String::from("\nSetup done.")))
+}

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -3,6 +3,7 @@
 pub mod build;
 pub mod direnv;
 pub mod info;
+pub mod init;
 pub mod shell;
 pub mod upgrade;
 pub mod watch;


### PR DESCRIPTION
Implements an `init` command that writes a default shell.nix and .envrc to $CWD if those files don't exist already.

Should fix #41 (?) however it does nothing about validating whether or not the existing `shell.nix` is valid - which is something @Profpatsch mentioned in #41 