### PR TITLE
Travis cargo cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@
         $HOME/.cargo
       - >-
         $TRAVIS_BUILD_DIR/target
+    "env":
+    - >-
+      CACHE_NAME=linux
     "language": >-
       nix
     "name": >-
@@ -66,6 +69,9 @@
         $HOME/.cargo
       - >-
         $TRAVIS_BUILD_DIR/target
+    "env":
+    - >-
+      CACHE_NAME=macos
     "language": >-
       nix
     "name": >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@
 
       source ./.travis_fold.sh
 
-      travis_fold ci_check \
+      lorri_travis_fold ci_check \
         nix-shell --quiet --arg isDevelopmentShell false --run ci_check
-      travis_fold travis-yml-gen \
+      lorri_travis_fold travis-yml-gen \
         cat $(nix-build --quiet ./.travis.yml.nix --no-out-link) > .travis.yml
-      travis_fold travis-yml-idempotent \
+      lorri_travis_fold travis-yml-idempotent \
         git diff -q ./.travis.yml
   - "before_cache":
     - >-
@@ -51,11 +51,11 @@
 
       source ./.travis_fold.sh
 
-      travis_fold ci_check \
+      lorri_travis_fold ci_check \
         nix-shell --quiet --arg isDevelopmentShell false --run ci_check
-      travis_fold travis-yml-gen \
+      lorri_travis_fold travis-yml-gen \
         cat $(nix-build --quiet ./.travis.yml.nix --no-out-link) > .travis.yml
-      travis_fold travis-yml-idempotent \
+      lorri_travis_fold travis-yml-idempotent \
         git diff -q ./.travis.yml
   - "language": >-
       nix
@@ -70,11 +70,11 @@
 
       source ./.travis_fold.sh
 
-      travis_fold lorri-nix-build \
+      lorri_travis_fold lorri-nix-build \
         nix-build
-      travis_fold lorri-install \
+      lorri_travis_fold lorri-install \
         nix-env -i ./result
-      travis_fold lorri-self-upgrade \
+      lorri_travis_fold lorri-self-upgrade \
         lorri self-upgrade local $(pwd)
   - "language": >-
       nix
@@ -89,9 +89,9 @@
 
       source ./.travis_fold.sh
 
-      travis_fold lorri-nix-build \
+      lorri_travis_fold lorri-nix-build \
         nix-build
-      travis_fold lorri-install \
+      lorri_travis_fold lorri-install \
         nix-env -i ./result
-      travis_fold lorri-self-upgrade \
+      lorri_travis_fold lorri-self-upgrade \
         lorri self-upgrade local $(pwd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,14 @@
   nix
 "matrix":
   "include":
-  - "language": >-
+  - "before_cache":
+    - >-
+      rm -rf /home/travis/.cargo/registry
+    "cache":
+      "directories":
+      - >-
+        /home/travis/cargo
+    "language": >-
       nix
     "name": >-
       cargo build & linters
@@ -24,7 +31,14 @@
         cat $(nix-build --quiet ./.travis.yml.nix --no-out-link) > .travis.yml
       travis_fold travis-yml-idempotent \
         git diff -q ./.travis.yml
-  - "language": >-
+  - "before_cache":
+    - >-
+      rm -rf /home/travis/.cargo/registry
+    "cache":
+      "directories":
+      - >-
+        /home/travis/cargo
+    "language": >-
       nix
     "name": >-
       cargo build & linters

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,25 @@
   "include":
   - "before_cache":
     - >-
-      rm -rf /home/travis/.cargo/registry
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/liblorri.rlib"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/build/lorri-*"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/deps/lorri-*"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/deps/liblorri-*"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/incremental/lorri-*"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/.fingerprint/lorri-*"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/incremental/build_script_build-*"
     "cache":
       "directories":
       - >-
-        /home/travis/cargo
+        $HOME/.cargo
+      - >-
+        $TRAVIS_BUILD_DIR/target
     "language": >-
       nix
     "name": >-
@@ -33,11 +47,25 @@
         git diff -q ./.travis.yml
   - "before_cache":
     - >-
-      rm -rf /home/travis/.cargo/registry
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/liblorri.rlib"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/build/lorri-*"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/deps/lorri-*"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/deps/liblorri-*"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/incremental/lorri-*"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/.fingerprint/lorri-*"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/incremental/build_script_build-*"
     "cache":
       "directories":
       - >-
-        /home/travis/cargo
+        $HOME/.cargo
+      - >-
+        $TRAVIS_BUILD_DIR/target
     "language": >-
       nix
     "name": >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@
     - >-
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/liblorri.rlib"
     - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/lorri*"
+    - >-
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/build/lorri-*"
     - >-
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/deps/lorri-*"
@@ -20,6 +22,12 @@
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/.fingerprint/lorri-*"
     - >-
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/incremental/build_script_build-*"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/direnv-*"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/deps/direnv-*"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/incremental/direnv-*"
     "cache":
       "directories":
       - >-
@@ -52,6 +60,8 @@
     - >-
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/liblorri.rlib"
     - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/lorri*"
+    - >-
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/build/lorri-*"
     - >-
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/deps/lorri-*"
@@ -63,6 +73,12 @@
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/.fingerprint/lorri-*"
     - >-
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/incremental/build_script_build-*"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/direnv-*"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/deps/direnv-*"
+    - >-
+      rm -rvf "$TRAVIS_BUILD_DIR/target/debug/incremental/direnv-*"
     "cache":
       "directories":
       - >-

--- a/.travis.yml.nix
+++ b/.travis.yml.nix
@@ -55,6 +55,7 @@ let
         in (map rmTarget [
           "lib${projectname}.rlib"
           # our own binaries/libraries (keep all other deps)
+          "${projectname}*"
           "build/${projectname}-*"
           "deps/${projectname}-*"
           "deps/lib${projectname}-*"
@@ -62,6 +63,10 @@ let
           ".fingerprint/${projectname}-*"
           # build script executable
           "incremental/build_script_build-*"
+          # TODO: the direnv integration test is not deterministic
+          "direnv-*"
+          "deps/direnv-*"
+          "incremental/direnv-*"
         ]);
         # TODO: this might improve things, but we don’t want
         # to open another `nix-shell` (because it takes a few seconds)

--- a/.travis.yml.nix
+++ b/.travis.yml.nix
@@ -42,6 +42,8 @@ let
         travis_fold travis-yml-idempotent \
           git diff -q ./.travis.yml
       '';
+      before_cache = [ "rm -rf /home/travis/.cargo/registry" ];
+      cache.directories = [ "/home/travis/cargo" ];
     };
   };
 

--- a/.travis.yml.nix
+++ b/.travis.yml.nix
@@ -49,7 +49,7 @@ let
     };
 
     # cache rust dependency building
-    cache = {
+    cache = name: {
       before_cache =
         let rmTarget = path: ''rm -rvf "$TRAVIS_BUILD_DIR/target/debug/${path}"'';
         in (map rmTarget [
@@ -67,6 +67,7 @@ let
         # to open another `nix-shell` (because it takes a few seconds)
         # ++ [ "cargo clean -p ${projectname}" ];
       cache.directories = [ "$HOME/.cargo" "$TRAVIS_BUILD_DIR/target" ];
+      env = [ "CACHE_NAME=${name}" ];
     };
   };
 
@@ -76,8 +77,8 @@ let
     matrix.include = [
       # Verifying lints on macOS and Linux ensures nix-shell works
       # on both platforms.
-      (hosts.linux // scripts.lints // scripts.cache)
-      (hosts.macos // scripts.lints // scripts.cache)
+      (hosts.linux // scripts.lints // (scripts.cache "linux"))
+      (hosts.macos // scripts.lints // (scripts.cache "macos"))
 
       (hosts.linux // scripts.builds)
       (hosts.macos // scripts.builds)

--- a/.travis.yml.nix
+++ b/.travis.yml.nix
@@ -1,5 +1,5 @@
 let
-  pkgs = import <nixpkgs> {};
+  pkgs = import ./nix/nixpkgs.nix {};
 
   projectname = "lorri";
 
@@ -87,6 +87,8 @@ in pkgs.runCommand "travis.yml" {
   buildInputs = [ pkgs.remarshal ];
   passAsFile = [ "jobs" ];
   jobs = builtins.toJSON jobs;
+  preferLocalBuild = true;
+  allowSubstitutes = false;
 }
 ''
   remarshal -if json -i $jobsPath -of yaml -o $out --yaml-style ">"

--- a/.travis.yml.nix
+++ b/.travis.yml.nix
@@ -21,11 +21,11 @@ let
       script = ''
         set -e
         source ./.travis_fold.sh
-        travis_fold lorri-nix-build \
+        lorri_travis_fold lorri-nix-build \
           nix-build
-        travis_fold lorri-install \
+        lorri_travis_fold lorri-install \
           nix-env -i ./result
-        travis_fold lorri-self-upgrade \
+        lorri_travis_fold lorri-self-upgrade \
           lorri self-upgrade local $(pwd)
       '';
     };
@@ -35,11 +35,11 @@ let
       script = ''
         set -e
         source ./.travis_fold.sh
-        travis_fold ci_check \
+        lorri_travis_fold ci_check \
           nix-shell --quiet --arg isDevelopmentShell false --run ci_check
-        travis_fold travis-yml-gen \
+        lorri_travis_fold travis-yml-gen \
           cat $(nix-build --quiet ./.travis.yml.nix --no-out-link) > .travis.yml
-        travis_fold travis-yml-idempotent \
+        lorri_travis_fold travis-yml-idempotent \
           git diff -q ./.travis.yml
       '';
       before_cache = [ "rm -rf /home/travis/.cargo/registry" ];

--- a/.travis_fold.sh
+++ b/.travis_fold.sh
@@ -1,5 +1,5 @@
 # fold a named ($1) command in travisCI
-function travis_fold() {
+function lorri_travis_fold() {
     name=$1
     shift
     echo "travis_fold:start:$name"

--- a/shell.nix
+++ b/shell.nix
@@ -132,5 +132,5 @@ pkgs.mkShell rec {
   '');
 
   preferLocalBuild = true;
-  buildUseSubstitutes = false;
+  allowSubstitutes = false;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -84,18 +84,18 @@ pkgs.mkShell rec {
 
       set -x
 
-      travis_fold script-tests ./script-tests/run-all.sh
+      lorri_travis_fold script-tests ./script-tests/run-all.sh
       scripttests=$?
 
-      travis_fold cargo-test cargo test
+      lorri_travis_fold cargo-test cargo test
       cargotestexit=$?
 
-      travis_fold cargo-fmt \
+      lorri_travis_fold cargo-fmt \
         sh -c 'cargo fmt && git diff --exit-code'
       cargofmtexit=$?
 
       RUSTFLAGS='-D warnings' \
-        travis_fold cargo-clippy cargo clippy
+        lorri_travis_fold cargo-clippy cargo clippy
       cargoclippyexit=$?
 
       set +x


### PR DESCRIPTION
Add caching to the travis (non-nix-build) jobs.

Before: 
![screenshot](https://user-images.githubusercontent.com/3153638/58731618-80a17c80-83ef-11e9-9e67-2171cca97c0c.png)

After:
![screenshot](https://user-images.githubusercontent.com/3153638/58731622-85663080-83ef-11e9-98d5-26b10934a2a7.png)

Now both runs spend most of their time in fetching the nightly rust toolchain and the MacOS builder spends another 2 minutes or so setting up a multi-user nix daemon when a single-user install would suffice.

The `nix-build` runs could also be sped up by passing the cargo cache manually to the build.