### PR TITLE
Actually support Go

### DIFF
--- a/nix/bogus-nixpkgs/stdenv/setup
+++ b/nix/bogus-nixpkgs/stdenv/setup
@@ -80,6 +80,11 @@ addToSearchPathWithCustomDelimiter() {
     fi
 }
 
+# preHook is the very first hook called by Nixpkgs' $stdenv/setup,
+# and is the earliest moment we can affect execution.
+# https://github.com/NixOS/nixpkgs/blob/22a765d0da7070311e5b8c2bb29fa496c833dae5/pkgs/stdenv/generic/setup.sh#L284
+runHook preHook
+
 # GOPATH and other environment variables are set in various hooks
 # in Nixpkgs' stdenv. Which hook is generally not significant, other
 # than general ordering. All the hooks but shellHook are called from

--- a/nix/bogus-nixpkgs/stdenv/setup
+++ b/nix/bogus-nixpkgs/stdenv/setup
@@ -79,3 +79,10 @@ addToSearchPathWithCustomDelimiter() {
         export "${varName}=${!varName:+${!varName}${delimiter}}${dir}"
     fi
 }
+
+# GOPATH and other environment variables are set in various hooks
+# in Nixpkgs' stdenv. Which hook is generally not significant, other
+# than general ordering. All the hooks but shellHook are called from
+# within $stdenv/setup, so lorriMockSetupHook can stand in for all
+# user-supplied hooks.
+runHook lorriMockSetupHook

--- a/release.nix
+++ b/release.nix
@@ -13,6 +13,10 @@
           true.
 
           This version does, actually, do that.
+
+          We also fixed a bug where appended environment variables
+          would include a leading delimiter even if it wasn't
+          previously set.
         '';
       }
       {

--- a/release.nix
+++ b/release.nix
@@ -6,6 +6,16 @@
     # Find the current version number with `git log --prety=%h | wc -l`
     entries = [
       {
+        version = 132;
+        changes = ''
+          Version #130 claimed to add Go support through GOPATH and
+          the appended environment variables, however this wasn't
+          true.
+
+          This version does, actually, do that.
+        '';
+      }
+      {
         version = 130;
         changes = ''
           `lorri watch` now supports executing shellHooks.

--- a/src/ops/direnv/envrc.bash
+++ b/src/ops/direnv/envrc.bash
@@ -51,7 +51,9 @@ function append() {
 
     # re-set $varname's variable to the contents of varname's
     # reference, plus the current (updated on the export) contents.
-    eval "$varname=$original$separator${!varname}"
+    # however, exclude the ${separator} unless ${original} starts
+    # with a value
+    eval "$varname=${original:+${original}${separator}}${!varname}"
 }
 
 varmap() {

--- a/src/ops/direnv/envrc.bash
+++ b/src/ops/direnv/envrc.bash
@@ -27,7 +27,9 @@ function prepend() {
 
     # re-set $varname's variable to the contents of varname's
     # reference, plus the current (updated on the export) contents.
-    eval "$varname=${!varname}$separator$original"
+    # however, exclude the ${separator} unless ${original} starts
+    # with a value
+    eval "$varname=${!varname}${original:+${separator}${original}}"
 }
 
 function append() {

--- a/tests/integration/bug23_gopath/shell.nix
+++ b/tests/integration/bug23_gopath/shell.nix
@@ -1,7 +1,7 @@
 with import ../../../nix/bogus-nixpkgs {};
 mkShell {
   env = {
-    shellHook = ''
+    lorriMockSetupHook = ''
       mkdir -p /tmp/foo/bar
       addToSearchPathWithCustomDelimiter : GOPATH /tmp/foo/bar
     '';

--- a/tests/integration/bug23_setuphook.rs
+++ b/tests/integration/bug23_setuphook.rs
@@ -1,0 +1,17 @@
+use direnv::DirenvValue;
+use direnvtestcase::DirenvTestCase;
+use std::env;
+
+#[test]
+fn bug23_shell_hook() {
+    env::set_var("EXAMPLE", "my-neat-path");
+    let mut testcase = DirenvTestCase::new("bug23_setuphook");
+    testcase.evaluate().expect("Failed to build the first time");
+
+    let env = testcase.get_direnv_variables();
+    println!("{:?}", env);
+    assert_eq!(
+        env.get_env("EXAMPLE"),
+        DirenvValue::Value("my-neat-path:/tmp/foo/bar")
+    );
+}

--- a/tests/integration/bug23_setuphook/shell.nix
+++ b/tests/integration/bug23_setuphook/shell.nix
@@ -1,0 +1,9 @@
+with import ../../../nix/bogus-nixpkgs {};
+mkShell {
+  env = {
+    shellHook = ''
+      mkdir -p /tmp/foo/bar
+      addToSearchPathWithCustomDelimiter : EXAMPLE /tmp/foo/bar
+    '';
+  };
+}

--- a/tests/integration/direnvtestcase.rs
+++ b/tests/integration/direnvtestcase.rs
@@ -68,7 +68,7 @@ impl DirenvTestCase {
 
         let mut env = self.direnv_cmd();
         env.args(&["export", "json"]);
-        let result = env.output().expect("Failed to run direnv allow");
+        let result = env.output().expect("Failed to run direnv export json");
         assert!(result.status.success());
 
         serde_json::from_slice(&result.stdout).unwrap()

--- a/tests/integration/envrc.rs
+++ b/tests/integration/envrc.rs
@@ -63,3 +63,16 @@ fn trivial_v2() {
     assert_eq!(env.get_env("FOOBAR"), DirenvValue::Value("TUX"));
     assert_eq!(env.get_env("GOPATH"), DirenvValue::Value("FOO:BAR"));
 }
+
+#[test]
+fn v2_gopath_previously_unset() {
+    let env = EnvrcTestCase::new()
+        .ambient_env("PATH", &env::var("PATH").unwrap())
+        .project_env(ProjectEnvBuilderV2::new().append("GOPATH", ":", "BAR"))
+        .unwrap()
+        .get_direnv_variables();
+
+    println!("{:?}", env);
+
+    assert_eq!(env.get_env("GOPATH"), DirenvValue::Value("BAR"));
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -5,6 +5,7 @@ extern crate tempfile;
 extern crate serde_derive;
 
 mod bug23_gopath;
+mod bug23_setuphook;
 mod direnv;
 mod direnvtestcase;
 mod envrc;


### PR DESCRIPTION
#75 implemented support for shellHooks, but ... oops: Go doesn't use shellHooks to setup GOPATH.

This code monkeypatches much sooner: https://github.com/NixOS/nixpkgs/blob/22a765d0da7070311e5b8c2bb29fa496c833dae5/pkgs/stdenv/generic/setup.sh#L238-L284

and correctly supports GOPATH.

It also fixes a bit of an annoying bug where an appended variable would be appended, including a delimiter, even if the variable was empty before: https://github.com/target/lorri/commit/664727ad8159557362cf5c5359030009d4cf0aa7

cc @mmlb who found and helped debug this problem. (and tested it fixed it!)