### PR TITLE
default.nix: Use nix-gitignore instead of fetchGit to filter src

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,6 @@
 {
   pkgs ? import ./nix/nixpkgs.nix { },
-  src ? builtins.fetchGit {
-    url = ./.;
-    ref = "HEAD";
-  }
+  src ? pkgs.nix-gitignore.gitignoreSource [".git/"] ./.
 }:
 pkgs.rustPlatform.buildRustPackage rec {
   name = "lorri";


### PR DESCRIPTION
Using `builtins.fetchGit` has multiple problems, it makes nix cache
for some time (1 hour?) which means changes to the source directory
are (silently) ignored.

It also requires a `.git` dir to exist, which is not the case for
distribution archives, and thus breaks `nix-env` on our rolling
release branch.

Closes: https://github.com/target/lorri/issues/92

You can test it with `nix-env -if https://github.com/target/lorri/archive/default.nix-use-nix-gitignore.tar.gz` cc @PierreR