### PR TITLE
Install command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,6 +54,10 @@ pub enum Command {
     /// Bootstrap files for a new setup
     #[structopt(name = "init")]
     Init,
+
+    /// Install the current environment.
+    #[structopt(name = "install", alias = "i")]
+    Install,
 }
 
 /// Send a message with a lorri project.

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,9 @@ use lorri::locate_file;
 use lorri::NixFile;
 
 use lorri::cli::{Arguments, Command};
-use lorri::ops::{daemon, direnv, info, init, ping, shell, upgrade, watch, ExitError, OpResult};
+use lorri::ops::{
+    daemon, direnv, info, init, install, ping, shell, upgrade, watch, ExitError, OpResult,
+};
 use lorri::project::Project;
 use std::env;
 use structopt::StructOpt;
@@ -86,6 +88,10 @@ fn run_command(opts: Arguments) -> OpResult {
         Command::Ping_(p) => ping::main(p.nix_file),
 
         Command::Init => init::main(TRIVIAL_SHELL_SRC, DEFAULT_ENVRC),
+
+        Command::Install => {
+            get_shell_nix().and_then(|sn| install::main(create_project(&paths, sn)?))
+        }
     }
 }
 

--- a/src/ops/direnv/mod.rs
+++ b/src/ops/direnv/mod.rs
@@ -32,7 +32,7 @@ pub fn main(project: Project) -> OpResult {
 
     if !shell_root.exists() {
         return Err(ExitError::errmsg(
-            "Please start `lorri daemon` or run `lorri watch` before using direnv integration.",
+            "Please start `lorri daemon`, run `lorri watch`, or simply `lorri install` before using direnv integration.",
         ));
     }
 

--- a/src/ops/install.rs
+++ b/src/ops/install.rs
@@ -1,0 +1,15 @@
+//! Run a BuildLoop for `shell.nix`, but only once.
+//! Can be used together with `direnv`.
+use crate::build_loop::BuildLoop;
+use crate::ops::{ok, OpResult};
+use crate::project::Project;
+
+/// See the documentation for lorri::cli::Command::Shell for more
+/// details.
+pub fn main(project: Project) -> OpResult {
+    let mut build_loop = BuildLoop::new(&project);
+    let result = build_loop.once();
+
+    println!("{:#?}", result);
+    ok()
+}

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -4,6 +4,7 @@ pub mod daemon;
 pub mod direnv;
 pub mod info;
 pub mod init;
+pub mod install;
 pub mod ping;
 pub mod shell;
 pub mod upgrade;


### PR DESCRIPTION
Adds a simple install command, so that users don't need to run `lorri daemon` or `lorri watch` just to have the shell root built. This makes lorri conform to most people's expectations of how tools like this work, where you have an `init` phase that initializes config, and an `install` phase that will do the setup based on the current configuration.

This really only does the same thing as `watch` but using the `once` mode of the build loop.

Based off #122, preventing merge conflicts. Can be rebased when needed.