### PR TITLE
nix, builder: Fix nix output parsing

### DIFF
--- a/src/build_loop.rs
+++ b/src/build_loop.rs
@@ -36,7 +36,7 @@ pub struct BuildResults {
 #[derive(Debug, Clone)]
 pub struct BuildExitFailure {
     /// stderr log output
-    pub log_lines: Vec<String>,
+    pub log_lines: Vec<std::ffi::OsString>,
 }
 
 /// The BuildLoop repeatedly builds the Nix expression in

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -73,7 +73,11 @@ pub fn run(root_nix_file: &NixFile, cas: &ContentAddressable) -> Result<Info, Er
         });
 
     let produced_drvs: thread::JoinHandle<std::io::Result<Vec<PathBuf>>> =
-        thread::spawn(move || ::nix::parse_nix_output(BufReader::new(stdout), PathBuf::from));
+        thread::spawn(move || {
+            osstrlines::Lines::from(BufReader::new(stdout))
+                .map(|line| line.map(PathBuf::from))
+                .collect::<Result<Vec<PathBuf>, _>>()
+        });
 
     let (exec_result, produced_drvs, results) = (
         child.wait()?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub mod logging;
 pub mod mpsc;
 pub mod nix;
 pub mod ops;
+pub mod osstrlines;
 pub mod pathreduction;
 pub mod project;
 pub mod roots;

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -32,6 +32,7 @@
 //! }
 //! ```
 
+use osstrlines;
 use serde_json;
 use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
@@ -296,7 +297,9 @@ impl CallOpts {
 
         if output.status.success() {
             let stdout: &[u8] = &output.stdout;
-            let paths: Vec<PathBuf> = ::nix::parse_nix_output(stdout, PathBuf::from)?;
+            let paths: Vec<PathBuf> = osstrlines::Lines::from(stdout)
+                .map(|line| line.map(PathBuf::from))
+                .collect::<Result<Vec<PathBuf>, _>>()?;
 
             if let Ok(vec1) = Vec1::from_vec(paths) {
                 Ok((vec1, GcRootTempDir(gc_root_dir)))

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -34,8 +34,9 @@
 
 use serde_json;
 use std::collections::HashMap;
-use std::ffi::OsStr;
-use std::os::unix::ffi::OsStrExt;
+use std::ffi::{OsStr, OsString};
+use std::io::BufRead;
+use std::os::unix::ffi::OsStringExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use vec1::Vec1;
@@ -294,7 +295,8 @@ impl CallOpts {
         let output = cmd.output()?;
 
         if output.status.success() {
-            let paths: Vec<PathBuf> = ::nix::parse_nix_output(&output.stdout, PathBuf::from);
+            let stdout: &[u8] = &output.stdout;
+            let paths: Vec<PathBuf> = ::nix::parse_nix_output(stdout, PathBuf::from)?;
 
             if let Ok(vec1) = Vec1::from_vec(paths) {
                 Ok((vec1, GcRootTempDir(gc_root_dir)))
@@ -339,19 +341,25 @@ impl CallOpts {
 
 /// Helper function to correctly parse the output of a `std::process::Output`’s
 /// `stdout` and `stderr` for nix outputs.
-pub fn parse_nix_output<'a, T, F>(output: &'a [u8], f: F) -> Vec<T>
+pub fn parse_nix_output<B, T, F>(output: B, f: F) -> std::io::Result<Vec<T>>
 where
-    F: Fn(&'a OsStr) -> T,
+    B: BufRead,
+    F: Fn(OsString) -> T,
 {
     output
         // We can split on \n to separate lines, because nix only runs in POSIX environments.
         // Using `lines()` means having to convert to UTF-8 first,
         // and nix output is not guaranteed to be valid UTF-8.
         // (think for example a derivation that outputs random data).
-        .split(|b| &b'\n' == b)
-        .map(std::ffi::OsStr::from_bytes)
-        .filter(|s| !s.is_empty())
-        .map(f)
+        .split(b'\n')
+        // split returns a Result<Vec<u8>>, so we unfortunately have
+        // to map over the Result for the rest of this iterator chain.
+        .filter(|line| match line {
+            Ok(l) => !l.is_empty(),
+            // errors shouldn’t be discarded
+            Err(_) => true,
+        })
+        .map(|line| line.map(|l| (&f)(std::ffi::OsString::from_vec(l))))
         .collect()
 }
 

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -35,9 +35,7 @@
 use osstrlines;
 use serde_json;
 use std::collections::HashMap;
-use std::ffi::{OsStr, OsString};
-use std::io::BufRead;
-use std::os::unix::ffi::OsStringExt;
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use vec1::Vec1;
@@ -340,30 +338,6 @@ impl CallOpts {
 
         ret
     }
-}
-
-/// Helper function to correctly parse the output of a `std::process::Output`’s
-/// `stdout` and `stderr` for nix outputs.
-pub fn parse_nix_output<B, T, F>(output: B, f: F) -> std::io::Result<Vec<T>>
-where
-    B: BufRead,
-    F: Fn(OsString) -> T,
-{
-    output
-        // We can split on \n to separate lines, because nix only runs in POSIX environments.
-        // Using `lines()` means having to convert to UTF-8 first,
-        // and nix output is not guaranteed to be valid UTF-8.
-        // (think for example a derivation that outputs random data).
-        .split(b'\n')
-        // split returns a Result<Vec<u8>>, so we unfortunately have
-        // to map over the Result for the rest of this iterator chain.
-        .filter(|line| match line {
-            Ok(l) => !l.is_empty(),
-            // errors shouldn’t be discarded
-            Err(_) => true,
-        })
-        .map(|line| line.map(|l| (&f)(std::ffi::OsString::from_vec(l))))
-        .collect()
 }
 
 /// Possible error conditions encountered when executing Nix evaluation commands.

--- a/src/osstrlines.rs
+++ b/src/osstrlines.rs
@@ -1,0 +1,73 @@
+//! An implementation of BufRead's lines(), but for producing OsString
+//!
+//! See https://doc.rust-lang.org/src/std/io/mod.rs.html#2241 for
+//! the reference implementation.
+
+use std::ffi::OsString;
+use std::io::{BufRead, Result};
+use std::os::unix::ffi::OsStringExt;
+
+/// An iterator over the OsString lines of an instance of `BufRead`.
+#[derive(Debug)]
+pub struct Lines<B> {
+    buf: B,
+}
+
+impl<B: BufRead> Lines<B> {
+    /// Returns an iterator over the lines of this reader.
+    ///
+    /// The iterator returned from this function will yield instances of
+    /// `io::Result<OsString>`. Each string returned will
+    /// *not* have a newline byte (the 0xA byte) or CRLF (0xD, 0xA bytes)
+    /// at the end.
+    ///
+    /// # Examples
+    ///
+    /// `std::io::Cursor` is a type that implements `BufRead`. In
+    /// this example, we use `Cursor` to iterate over all the lines in a byte
+    /// slice.
+    ///
+    /// ```
+    /// use std::io::{self, BufRead};
+    /// use std::ffi::{OsStr, OsString};
+    /// use std::os::unix::ffi::OsStrExt;
+    /// use lorri::osstrlines::Lines;
+    ///
+    /// let cursor = io::Cursor::new(b"lorem\nipsum\r\ndolor\n\xab\xbc\xcd\xde\xde\xef");
+    ///
+    /// let mut lines_iter = Lines::from(cursor).map(|l| l.unwrap());
+    /// assert_eq!(lines_iter.next(), Some(OsString::from("lorem")));
+    /// assert_eq!(lines_iter.next(), Some(OsString::from("ipsum")));
+    /// assert_eq!(lines_iter.next(), Some(OsString::from("dolor")));
+    /// assert_eq!(lines_iter.next(), Some(OsStr::from_bytes(b"\xab\xbc\xcd\xde\xde\xef").to_owned()));
+    /// assert_eq!(lines_iter.next(), None);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Each line of the iterator has the same error semantics as BufRead::read_until.
+    pub fn from(reader: B) -> Lines<B> {
+        Lines { buf: reader }
+    }
+}
+
+impl<B: BufRead> Iterator for Lines<B> {
+    type Item = Result<OsString>;
+
+    fn next(&mut self) -> Option<Result<OsString>> {
+        let mut buf = vec![];
+        match self.buf.read_until(b'\n', &mut buf) {
+            Ok(0) => None,
+            Ok(_n) => {
+                if buf.ends_with(&[b'\n']) {
+                    buf.pop();
+                    if buf.ends_with(&[b'\r']) {
+                        buf.pop();
+                    }
+                }
+                Some(Ok(std::ffi::OsString::from_vec(buf)))
+            }
+            Err(e) => Some(Err(e)),
+        }
+    }
+}


### PR DESCRIPTION
Split out from https://github.com/target/lorri/pull/117

Before, the nix output was parsed into `str`/`String` before parsing
it into lines (which is the behavior of the various `.lines()`
methods).

We can, however, not assume that nix output is valid UTF-8. Take for
example the following derivation:

```
with import <nixpkgs> {};
runCommand "foo" {} ''
  dd if=/dev/urandom of=./foo bs=1M count=1
  cat ./foo
  touch $out
''
```

which prints 1 megabyte of random output to stdout (and thus to nix’s
`stderr`). This random data is not valid UTF-8, which means lorri is
going to choke on the derivation output and crash with a decoding
error.

Instead, we keep the output a `Vec<u8>`, convert it to an
`OsString` (which is a wrapper around `Vec<u8>` on POSIX systems) and
split on `\n` (which is the line separator on POSIX systems).

As a nice side-effect, we can remove the use of threads from the
`builder.rs` code (by replacing with `wait_with_output()`) and unify
the output parsing behavior).