### PR TITLE
feat: add option to define the shell.nix location

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,15 +25,15 @@ pub enum Command {
     /// Emit shell script intended to be evaluated as part of
     /// direnv's .envrc, via: `eval "$(lorri direnv)"`
     #[structopt(name = "direnv")]
-    Direnv,
+    Direnv(NixShellFile),
 
     /// Show information about the current Lorri project
     #[structopt(name = "info", alias = "information")]
-    Info,
+    Info(NixShellFile),
 
     /// Build `shell.nix` whenever an input file changes
     #[structopt(name = "watch")]
-    Watch,
+    Watch(NixShellFile),
 
     /// Start the multi-project daemon. Replaces `lorri watch`
     #[structopt(name = "daemon")]
@@ -62,6 +62,14 @@ pub struct Ping_ {
     /// The .nix file to watch and build on changes.
     #[structopt(parse(from_os_str))]
     pub nix_file: NixFile,
+}
+
+///  Add parameter to define the shell file in the current directory to use
+#[derive(StructOpt, Debug)]
+pub struct NixShellFile {
+    /// The .nix file in the current directory to use
+    #[structopt(long = "shell-file", parse(from_os_str), default_value = "shell.nix")]
+    pub nix_file: PathBuf,
 }
 
 /// A stub struct to represent how what we want to upgrade to.

--- a/src/locate_file.rs
+++ b/src/locate_file.rs
@@ -22,7 +22,7 @@ impl From<std::io::Error> for FileLocationError {
 }
 
 /// Hunt for filename `name` in the current directory
-pub fn in_cwd(name: &str) -> Result<PathBuf, FileLocationError> {
+pub fn in_cwd(name: &PathBuf) -> Result<PathBuf, FileLocationError> {
     let mut path = env::current_dir()?;
     path.push(name);
     if path.is_file() {
@@ -36,18 +36,21 @@ pub fn in_cwd(name: &str) -> Result<PathBuf, FileLocationError> {
 mod tests {
     use super::{in_cwd, FileLocationError};
     use std::path::Path;
+    use std::path::PathBuf;
 
     #[test]
     fn test_locate_config_file() {
-        let result = in_cwd("shell.nix");
+        let mut path = PathBuf::from("shell.nix");
+        let result = in_cwd(&path);
         assert_eq!(
             result.expect("Should find the shell.nix in this projects' root"),
             Path::new(env!("CARGO_MANIFEST_DIR"))
                 .join("shell.nix")
                 .to_path_buf()
         );
-
-        let result = in_cwd("this-lorri-specific-file-probably-does-not-exist");
+        path.pop();
+        path.push("this-lorri-specific-file-probably-does-not-exist");
+        let result = in_cwd(&path);
 
         match result {
             Err(FileLocationError::NotFound) => (),


### PR DESCRIPTION
use --shell-file or -s option to declare the nix file to use when
running command info, watch, direnv

refs #116

:warning:  first time I contribute to a rust project.

thank you for this great project, it saves me a lot of time
thank you for marking this as good first issue