### PR TITLE
Graham/fix nix output parsing

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -73,7 +73,11 @@ pub fn run(root_nix_file: &NixFile, cas: &ContentAddressable) -> Result<Info, Er
         });
 
     let produced_drvs: thread::JoinHandle<std::io::Result<Vec<PathBuf>>> =
-        thread::spawn(move || ::nix::parse_nix_output(BufReader::new(stdout), PathBuf::from));
+        thread::spawn(move || {
+            osstrlines::Lines::from(BufReader::new(stdout))
+                .map(|line| line.map(PathBuf::from))
+                .collect::<Result<Vec<PathBuf>, _>>()
+        });
 
     let (exec_result, produced_drvs, results) = (
         child.wait()?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub mod logging;
 pub mod mpsc;
 pub mod nix;
 pub mod ops;
+pub mod osstrlines;
 pub mod pathreduction;
 pub mod project;
 pub mod roots;

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -32,6 +32,7 @@
 //! }
 //! ```
 
+use osstrlines;
 use serde_json;
 use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
@@ -296,7 +297,9 @@ impl CallOpts {
 
         if output.status.success() {
             let stdout: &[u8] = &output.stdout;
-            let paths: Vec<PathBuf> = ::nix::parse_nix_output(stdout, PathBuf::from)?;
+            let paths: Vec<PathBuf> = osstrlines::Lines::from(stdout)
+                .map(|line| line.map(PathBuf::from))
+                .collect::<Result<Vec<PathBuf>, _>>()?;
 
             if let Ok(vec1) = Vec1::from_vec(paths) {
                 Ok((vec1, GcRootTempDir(gc_root_dir)))

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -35,9 +35,7 @@
 use osstrlines;
 use serde_json;
 use std::collections::HashMap;
-use std::ffi::{OsStr, OsString};
-use std::io::BufRead;
-use std::os::unix::ffi::OsStringExt;
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use vec1::Vec1;
@@ -340,30 +338,6 @@ impl CallOpts {
 
         ret
     }
-}
-
-/// Helper function to correctly parse the output of a `std::process::Output`’s
-/// `stdout` and `stderr` for nix outputs.
-pub fn parse_nix_output<B, T, F>(output: B, f: F) -> std::io::Result<Vec<T>>
-where
-    B: BufRead,
-    F: Fn(OsString) -> T,
-{
-    output
-        // We can split on \n to separate lines, because nix only runs in POSIX environments.
-        // Using `lines()` means having to convert to UTF-8 first,
-        // and nix output is not guaranteed to be valid UTF-8.
-        // (think for example a derivation that outputs random data).
-        .split(b'\n')
-        // split returns a Result<Vec<u8>>, so we unfortunately have
-        // to map over the Result for the rest of this iterator chain.
-        .filter(|line| match line {
-            Ok(l) => !l.is_empty(),
-            // errors shouldn’t be discarded
-            Err(_) => true,
-        })
-        .map(|line| line.map(|l| (&f)(std::ffi::OsString::from_vec(l))))
-        .collect()
 }
 
 /// Possible error conditions encountered when executing Nix evaluation commands.

--- a/src/osstrlines.rs
+++ b/src/osstrlines.rs
@@ -1,0 +1,73 @@
+//! An implementation of BufRead's lines(), but for producing OsString
+//!
+//! See https://doc.rust-lang.org/src/std/io/mod.rs.html#2241 for
+//! the reference implementation.
+
+use std::ffi::OsString;
+use std::io::{BufRead, Result};
+use std::os::unix::ffi::OsStringExt;
+
+/// An iterator over the OsString lines of an instance of `BufRead`.
+#[derive(Debug)]
+pub struct Lines<B> {
+    buf: B,
+}
+
+impl<B: BufRead> Lines<B> {
+    /// Returns an iterator over the lines of this reader.
+    ///
+    /// The iterator returned from this function will yield instances of
+    /// `io::Result<OsString>`. Each string returned will
+    /// *not* have a newline byte (the 0xA byte) or CRLF (0xD, 0xA bytes)
+    /// at the end.
+    ///
+    /// # Examples
+    ///
+    /// `std::io::Cursor` is a type that implements `BufRead`. In
+    /// this example, we use `Cursor` to iterate over all the lines in a byte
+    /// slice.
+    ///
+    /// ```
+    /// use std::io::{self, BufRead};
+    /// use std::ffi::{OsStr, OsString};
+    /// use std::os::unix::ffi::OsStrExt;
+    /// use lorri::osstrlines::Lines;
+    ///
+    /// let cursor = io::Cursor::new(b"lorem\nipsum\r\ndolor\n\xab\xbc\xcd\xde\xde\xef");
+    ///
+    /// let mut lines_iter = Lines::from(cursor).map(|l| l.unwrap());
+    /// assert_eq!(lines_iter.next(), Some(OsString::from("lorem")));
+    /// assert_eq!(lines_iter.next(), Some(OsString::from("ipsum")));
+    /// assert_eq!(lines_iter.next(), Some(OsString::from("dolor")));
+    /// assert_eq!(lines_iter.next(), Some(OsStr::from_bytes(b"\xab\xbc\xcd\xde\xde\xef").to_owned()));
+    /// assert_eq!(lines_iter.next(), None);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Each line of the iterator has the same error semantics as BufRead::read_until.
+    pub fn from(reader: B) -> Lines<B> {
+        Lines { buf: reader }
+    }
+}
+
+impl<B: BufRead> Iterator for Lines<B> {
+    type Item = Result<OsString>;
+
+    fn next(&mut self) -> Option<Result<OsString>> {
+        let mut buf = vec![];
+        match self.buf.read_until(b'\n', &mut buf) {
+            Ok(0) => None,
+            Ok(_n) => {
+                if buf.ends_with(&[b'\n']) {
+                    buf.pop();
+                    if buf.ends_with(&[b'\r']) {
+                        buf.pop();
+                    }
+                }
+                Some(Ok(std::ffi::OsString::from_vec(buf)))
+            }
+            Err(e) => Some(Err(e)),
+        }
+    }
+}


### PR DESCRIPTION
The code in #133 is pretty good, check out these proposed patches for some feedback / suggestions

This borrows upstream Rust code to implement a Lines iterator which produces OsStrings, and replaces the parse_nix_output code to use it. From the commit where I drop that function:

> nix: drop parse_nix_output
>
> Prefer the iterator format, especially when we're able to
> use familiar forms of passing functions around.
>
> In this case the parse_nix_output function probably shouldn't
> skip newlines.
>
> Additionally, reducing the powerful model of iterators down
> to only supporting (and actually requiring) a single function
> isn't doing us much favor.

Finally, in the tests for the builder I add a proof-positive test to assert that the bytes come through and that the shell derivation is produced.