### PR TITLE
daemon: print message on start-up

### DIFF
--- a/src/ops/daemon.rs
+++ b/src/ops/daemon.rs
@@ -52,6 +52,8 @@ pub fn main() -> OpResult {
         }
     });
 
+    println!("lorri: ready");
+
     // For each build instruction, add the corresponding file
     // to the watch list.
     for start_build in accept_messages_rx {


### PR DESCRIPTION
This PR simply adds a little `lorri: ready` output when starting the daemon.

Fixes #142 