### PR TITLE
Fixed a Typo in the Travis cfg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@
       lorri_travis_fold travis-yml-idempotent \
         git diff -q ./.travis.yml
       lorri_travis_fold carnix-idempotent \
-        git diff -q ./.travis.yml
+        git diff -q ./Cargo.nix
 
   - "before_cache":
     - >-
@@ -113,7 +113,7 @@
       lorri_travis_fold travis-yml-idempotent \
         git diff -q ./.travis.yml
       lorri_travis_fold carnix-idempotent \
-        git diff -q ./.travis.yml
+        git diff -q ./Cargo.nix
 
   - "language": >-
       nix

--- a/.travis.yml.nix
+++ b/.travis.yml.nix
@@ -45,7 +45,7 @@ let
         lorri_travis_fold travis-yml-idempotent \
           git diff -q ./.travis.yml
         lorri_travis_fold carnix-idempotent \
-          git diff -q ./.travis.yml
+          git diff -q ./Cargo.nix
 
       '';
       # delete all our own artifacts from the cache dir


### PR DESCRIPTION
The `.travis.yml.nix` was diffing `.travis.yml` under the `carnix-idempotent` travis step, this is probably a typo and should be `Cargo.nix`.