### PR TITLE
daemon, build_loop, watch: crash on unrecoverable error

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -31,7 +31,7 @@ pub struct Daemon {
     handler_threads: HashMap<NixFile, std::thread::JoinHandle<()>>,
     /// Sending end that we pass to every `BuildLoop` the daemon controls.
     // TODO: this needs to transmit information to identify the builder with
-    build_events_tx: mpsc::Sender<::build_loop::Event>,
+    build_events_tx: mpsc::Sender<Result<::build_loop::Event, ::build_loop::UnrecoverableErrors>>,
     /// The handlers functions for incoming requests
     handler_fns: HandlerFns,
 }
@@ -42,7 +42,10 @@ impl Daemon {
     /// Create a new daemon. Also return an `mpsc::Receiver` that
     /// receives `build_loop::Event`s for all builders this daemon
     /// supervises.
-    pub fn new() -> (Daemon, mpsc::Receiver<::build_loop::Event>) {
+    pub fn new() -> (
+        Daemon,
+        mpsc::Receiver<Result<::build_loop::Event, ::build_loop::UnrecoverableErrors>>,
+    ) {
         let (tx, rx) = mpsc::channel();
         (
             Daemon {

--- a/src/ops/watch.rs
+++ b/src/ops/watch.rs
@@ -19,7 +19,14 @@ pub fn main(project: Project) -> OpResult {
     };
 
     for msg in rx {
-        println!("{:#?}", msg);
+        match msg {
+            // TODO: add human-message to get a nice stack & link for people to open an issue
+            Err(unrecoverable) => panic!(
+                "An unrecoverable error has occured. Please open an issue!\n{:#?}",
+                unrecoverable
+            ),
+            Ok(m) => println!("{:#?}", m),
+        }
     }
 
     build_thread.join().unwrap();

--- a/tests/daemon/main.rs
+++ b/tests/daemon/main.rs
@@ -75,7 +75,7 @@ pub fn start_job_with_ping() -> std::io::Result<()> {
         .recv_timeout(Duration::from_millis(100))
         .unwrap()
     {
-        build_loop::Event::Started => Ok(()),
+        Ok(build_loop::Event::Started) => Ok(()),
         ev => Err(Error::new(
             ErrorKind::Other,
             format!("didn’t expect event {:?}", ev),


### PR DESCRIPTION
Previously, we panic!()’ed in the build_loop, inside of a
forever-Thread, meaning the thread would die but the daemon continues
running.

This is solved by forwarding the message throught the existing channel
and handling it in the main thread.

Tested manually by stubbing out `run` in `builder` and verifying that the daemon crashes.

Closes: https://github.com/target/lorri/issues/120
cc @chreekat