### PR TITLE
CI: fix the ci_check return code accumulation

### DIFF
--- a/script-tests/run-all.sh
+++ b/script-tests/run-all.sh
@@ -7,5 +7,4 @@ shellcheck "$0"
 cd "$(dirname "$0")"
 
 shellcheck ../nix/bogus-nixpkgs/builder.sh
-shellcheck ../src/ops/prompt.sh
 shellcheck ../src/ops/direnv/envrc.bash

--- a/shell.nix
+++ b/shell.nix
@@ -113,7 +113,7 @@ pkgs.mkShell rec {
       echo "cargo fmt: $cargofmtexit"
       echo "cargo clippy: $cargoclippyexit"
 
-      sum=$((cargotestexit + cargofmtexit + cargoclippyexit))
+      sum=$((carnixupdate + scripttest + cargotestexit + cargofmtexit + cargoclippyexit))
       if [ "$sum" -gt 0 ]; then
         return 1
       fi


### PR DESCRIPTION
If we add new phases, we need to add them to the final status code
check as well, otherwise CI doesn’t fail if a phase fails.

Broken out of #117.