### PR TITLE
Bug 151/start lorri daemon

### DIFF
--- a/src/ops/direnv/envrc.bash
+++ b/src/ops/direnv/envrc.bash
@@ -157,7 +157,7 @@ export IN_NIX_SHELL=1
 if [ -f "$EVALUATION_ROOT/bash-export" ]; then
     # shellcheck disable=SC1090
     . "$EVALUATION_ROOT/bash-export"
-else
+elif [ -f "$EVALUATION_ROOT" ]; then
     # shellcheck disable=SC1090
     . "$EVALUATION_ROOT"
 fi


### PR DESCRIPTION
Fix #151
Fix #113 

1. Print a more correct warning to the user if the environment is not cached, or if the lorri daemon is not updated.
2. Simplify handling when the daemon isn't running by watching the socket, so we evaluate when the daemon starts.