### PR TITLE
add `lorri watch --once`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,15 +25,15 @@ pub enum Command {
     /// Emit shell script intended to be evaluated as part of
     /// direnv's .envrc, via: `eval "$(lorri direnv)"`
     #[structopt(name = "direnv")]
-    Direnv(NixShellFile),
+    Direnv(DirenvOptions),
 
     /// Show information about the current Lorri project
     #[structopt(name = "info", alias = "information")]
-    Info(NixShellFile),
+    Info(InfoOptions),
 
     /// Build `shell.nix` whenever an input file changes
     #[structopt(name = "watch")]
-    Watch(NixShellFile),
+    Watch(WatchOptions),
 
     /// Start the multi-project daemon. Replaces `lorri watch`
     #[structopt(name = "daemon")]
@@ -52,6 +52,33 @@ pub enum Command {
     Init,
 }
 
+/// Options for `watch` subcommand.
+#[derive(StructOpt, Debug)]
+pub struct DirenvOptions {
+    /// The .nix file in the current directory to use
+    #[structopt(long = "shell-file", parse(from_os_str), default_value = "shell.nix")]
+    pub nix_file: PathBuf,
+}
+
+/// Options for `watch` subcommand.
+#[derive(StructOpt, Debug)]
+pub struct InfoOptions {
+    /// The .nix file in the current directory to use
+    #[structopt(long = "shell-file", parse(from_os_str), default_value = "shell.nix")]
+    pub nix_file: PathBuf,
+}
+
+/// Options for `watch` subcommand.
+#[derive(StructOpt, Debug)]
+pub struct WatchOptions {
+    /// The .nix file in the current directory to use
+    #[structopt(long = "shell-file", parse(from_os_str), default_value = "shell.nix")]
+    pub nix_file: PathBuf,
+    /// Exit after a the first build
+    #[structopt(long = "once")]
+    pub once: bool,
+}
+
 /// Send a message with a lorri project.
 ///
 /// Pinging with a project tells the daemon that the project was recently interacted with.
@@ -62,14 +89,6 @@ pub struct Ping_ {
     /// The .nix file to watch and build on changes.
     #[structopt(parse(from_os_str))]
     pub nix_file: NixFile,
-}
-
-///  Add parameter to define the shell file in the current directory to use
-#[derive(StructOpt, Debug)]
-pub struct NixShellFile {
-    /// The .nix file in the current directory to use
-    #[structopt(long = "shell-file", parse(from_os_str), default_value = "shell.nix")]
-    pub nix_file: PathBuf,
 }
 
 /// A stub struct to represent how what we want to upgrade to.

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,17 +65,16 @@ fn create_project(paths: &constants::Paths, shell_nix: NixFile) -> Result<Projec
 fn run_command(opts: Arguments) -> OpResult {
     let paths = lorri::ops::get_paths()?;
     match opts.command {
-        Command::Info(p) => {
-            get_shell_nix(&p.nix_file).and_then(|sn| info::main(create_project(&paths, sn)?))
+        Command::Info(opts) => {
+            get_shell_nix(&opts.nix_file).and_then(|sn| info::main(create_project(&paths, sn)?))
         }
 
-        Command::Direnv(p) => {
-            get_shell_nix(&p.nix_file).and_then(|sn| direnv::main(create_project(&paths, sn)?))
+        Command::Direnv(opts) => {
+            get_shell_nix(&opts.nix_file).and_then(|sn| direnv::main(create_project(&paths, sn)?))
         }
 
-        Command::Watch(p) => {
-            get_shell_nix(&p.nix_file).and_then(|sn| watch::main(create_project(&paths, sn)?))
-        }
+        Command::Watch(opts) => get_shell_nix(&opts.nix_file)
+            .and_then(|sn| watch::main(create_project(&paths, sn)?, opts)),
 
         Command::Daemon => daemon::main(),
 

--- a/src/ops/watch.rs
+++ b/src/ops/watch.rs
@@ -1,28 +1,53 @@
 //! Run a BuildLoop for `shell.nix`, watching for input file changes.
 //! Can be used together with `direnv`.
-use crate::build_loop::BuildLoop;
-use crate::ops::{ok, OpResult};
+use crate::build_loop::{BuildError, BuildLoop};
+use crate::cli::WatchOptions;
+use crate::ops::{ok, ExitError, OpResult};
 use crate::project::Project;
+use std::fmt::Debug;
+use std::io::Write;
 use std::sync::mpsc::channel;
 use std::thread;
 
+// TODO: this should probably be something more structured
+fn print_build_message<A>(msg: A)
+where
+    A: Debug,
+{
+    println!("{:#?}", msg);
+}
+
 /// See the documentation for lorri::cli::Command::Shell for more
 /// details.
-pub fn main(project: Project) -> OpResult {
+pub fn main(project: Project, opts: WatchOptions) -> OpResult {
     let (tx, rx) = channel();
 
-    let build_thread = {
-        thread::spawn(move || {
-            let mut build_loop = BuildLoop::new(&project);
-            build_loop.forever(tx);
-        })
-    };
+    if opts.once {
+        let mut build_loop = BuildLoop::new(&project);
+        match build_loop.once() {
+            Ok(msg) => {
+                print_build_message(msg);
+                ok()
+            }
+            Err(BuildError::Unrecoverable(err)) => Err(ExitError::err(100, format!("{:?}", err))),
+            Err(BuildError::Recoverable(exit_failure)) => {
+                Err(ExitError::errmsg(format!("{:#?}", exit_failure)))
+            }
+        }
+    } else {
+        let build_thread = {
+            thread::spawn(move || {
+                let mut build_loop = BuildLoop::new(&project);
+                build_loop.forever(tx);
+            })
+        };
 
-    for msg in rx {
-        println!("{:#?}", msg);
+        for msg in rx {
+            print_build_message(msg);
+        }
+
+        build_thread.join().unwrap();
+
+        ok()
     }
-
-    build_thread.join().unwrap();
-
-    ok()
 }

--- a/src/ops/watch.rs
+++ b/src/ops/watch.rs
@@ -44,7 +44,6 @@ fn main_run_forever(project: Project) -> OpResult {
 
     for msg in rx {
         print_build_message(msg);
-        let _ = std::io::stdout().flush();
     }
 
     build_thread.join().unwrap();
@@ -52,10 +51,11 @@ fn main_run_forever(project: Project) -> OpResult {
     ok()
 }
 
-// TODO: this should probably be something more structured
+/// Print a build message to stdout and flush.
 fn print_build_message<A>(msg: A)
 where
     A: Debug,
 {
     println!("{:#?}", msg);
+    let _ = std::io::stdout().flush();
 }

--- a/src/ops/watch.rs
+++ b/src/ops/watch.rs
@@ -9,46 +9,53 @@ use std::io::Write;
 use std::sync::mpsc::channel;
 use std::thread;
 
+/// See the documentation for lorri::cli::Command::Shell for more
+/// details.
+pub fn main(project: Project, opts: WatchOptions) -> OpResult {
+    if opts.once {
+        main_run_once(project)
+    } else {
+        main_run_forever(project)
+    }
+}
+
+fn main_run_once(project: Project) -> OpResult {
+    let mut build_loop = BuildLoop::new(&project);
+    match build_loop.once() {
+        Ok(msg) => {
+            print_build_message(msg);
+            ok()
+        }
+        Err(BuildError::Unrecoverable(err)) => Err(ExitError::err(100, format!("{:?}", err))),
+        Err(BuildError::Recoverable(exit_failure)) => {
+            Err(ExitError::errmsg(format!("{:#?}", exit_failure)))
+        }
+    }
+}
+
+fn main_run_forever(project: Project) -> OpResult {
+    let (tx, rx) = channel();
+    let build_thread = {
+        thread::spawn(move || {
+            let mut build_loop = BuildLoop::new(&project);
+            build_loop.forever(tx);
+        })
+    };
+
+    for msg in rx {
+        print_build_message(msg);
+        let _ = std::io::stdout().flush();
+    }
+
+    build_thread.join().unwrap();
+
+    ok()
+}
+
 // TODO: this should probably be something more structured
 fn print_build_message<A>(msg: A)
 where
     A: Debug,
 {
     println!("{:#?}", msg);
-}
-
-/// See the documentation for lorri::cli::Command::Shell for more
-/// details.
-pub fn main(project: Project, opts: WatchOptions) -> OpResult {
-    let (tx, rx) = channel();
-
-    if opts.once {
-        let mut build_loop = BuildLoop::new(&project);
-        match build_loop.once() {
-            Ok(msg) => {
-                print_build_message(msg);
-                ok()
-            }
-            Err(BuildError::Unrecoverable(err)) => Err(ExitError::err(100, format!("{:?}", err))),
-            Err(BuildError::Recoverable(exit_failure)) => {
-                Err(ExitError::errmsg(format!("{:#?}", exit_failure)))
-            }
-        }
-    } else {
-        let build_thread = {
-            thread::spawn(move || {
-                let mut build_loop = BuildLoop::new(&project);
-                build_loop.forever(tx);
-            })
-        };
-
-        for msg in rx {
-            print_build_message(msg);
-            let _ = std::io::stdout().flush();
-        }
-
-        build_thread.join().unwrap();
-
-        ok()
-    }
 }

--- a/src/ops/watch.rs
+++ b/src/ops/watch.rs
@@ -44,6 +44,7 @@ pub fn main(project: Project, opts: WatchOptions) -> OpResult {
 
         for msg in rx {
             print_build_message(msg);
+            let _ = std::io::stdout().flush();
         }
 
         build_thread.join().unwrap();


### PR DESCRIPTION
Adds a `--once` argument to lorri watch, to only run one evaluation.

`lorri install` was proposed instead, but we don’t want it to sound
like the command changes the system of the user (think `make
install`).

Ultimately, `lorri watch` is going to be replaced by `lorri daemon`
completely, then we should introduce a `lorri run` command which does
the same as `lorri watch --once`.

Co-Authored-By: Graham Christensen <graham@grahamc.com>
Co-Authored-By: Tobias Pflug <tobias.pflug@tweag.io>