### PR TITLE
Set IN_NIX_SHELL to impure (#140)

### DIFF
--- a/src/logged-evaluation.nix
+++ b/src/logged-evaluation.nix
@@ -118,7 +118,7 @@ let
       # Export IN_NIX_SHELL to trick various Nix tooling to export
       # shell-friendly variables
 
-      export IN_NIX_SHELL=1
+      export IN_NIX_SHELL=impure
 
       # https://github.com/NixOS/nix/blob/92d08c02c84be34ec0df56ed718526c382845d1a/src/nix-build/nix-build.cc#
       [ -e $stdenv/setup ] && . $stdenv/setup

--- a/src/ops/direnv/envrc.bash
+++ b/src/ops/direnv/envrc.bash
@@ -158,7 +158,7 @@ function declare() {
     esac
 }
 
-export IN_NIX_SHELL=1
+export IN_NIX_SHELL=impure
 
 if [ -f "$EVALUATION_ROOT/bash-export" ]; then
     # shellcheck disable=SC1090


### PR DESCRIPTION
Sets IN_NIX_SHELL environment variable to `impure` instead of 1.

I think this should resolve https://github.com/target/lorri/issues/140 as I couldn't see any other references to IN_NIX_SHELL, but I should probably add a test as well? I checked it manually by checking the value of the environment variable with direnv/lorri in the development shell for this project.