### PR TITLE
Report cause of build

### DIFF
--- a/src/build_loop.rs
+++ b/src/build_loop.rs
@@ -8,7 +8,7 @@ use crate::pathreduction::reduce_paths;
 use crate::project::roots;
 use crate::project::roots::Roots;
 use crate::project::Project;
-use crate::watch::Watch;
+use crate::watch::{Reason, Watch};
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, Sender};
 
@@ -16,7 +16,7 @@ use std::sync::mpsc::{channel, Sender};
 #[derive(Clone, Debug)]
 pub enum Event {
     /// The build has started
-    Started,
+    Started(Reason),
     /// The build completed successfully
     Completed(BuildResults),
     /// The build command returned a failing exit status
@@ -64,12 +64,13 @@ impl<'a> BuildLoop<'a> {
     /// When new filesystem changes are detected while a build is
     /// still running, it is finished first before starting a new build.
     pub fn forever(&mut self, tx: Sender<Event>) {
+        let mut reason = Reason::ProjectAdded(self.project.nix_file.clone());
         loop {
             // TODO: Make err use Display instead of Debug.
             // Otherwise user errors (especially for IO errors)
             // are pretty hard to debug. Might need to review
             // whether we can handle some errors earlier than here.
-            tx.send(Event::Started)
+            tx.send(Event::Started(reason))
                 .expect("Failed to notify a started evaluation");
 
             match self.once() {
@@ -84,7 +85,11 @@ impl<'a> BuildLoop<'a> {
                 Err(BuildError::Unrecoverable(err)) => panic!("Unrecoverable error!\n{:#?}", err),
             }
 
-            self.watch.wait_for_change().expect("Waiter exited");
+            reason = match self.watch.wait_for_change() {
+                Ok(r) => r,
+                Err(msg) => Reason::UnknownEvent(msg)
+            }
+
         }
     }
 

--- a/src/socket/communicate.rs
+++ b/src/socket/communicate.rs
@@ -114,7 +114,6 @@ pub mod listener {
             Ok(std::thread::spawn(move || handler(unix_stream, comm_type)))
         }
     }
-
 }
 
 /// Clients that can talk to a `Listener`.
@@ -223,5 +222,4 @@ pub mod client {
     pub fn ping(timeout: Timeout) -> Client<NoMessage, Ping> {
         Client::bake(timeout, CommunicationType::Ping)
     }
-
 }

--- a/tests/daemon/main.rs
+++ b/tests/daemon/main.rs
@@ -75,7 +75,7 @@ pub fn start_job_with_ping() -> std::io::Result<()> {
         .recv_timeout(Duration::from_millis(100))
         .unwrap()
     {
-        build_loop::Event::Started => Ok(()),
+        build_loop::Event::Started(_) => Ok(()),
         ev => Err(Error::new(
             ErrorKind::Other,
             format!("didn’t expect event {:?}", ev),


### PR DESCRIPTION
This addresses #49 - The watch module gets a `Reason` type, and reports `FilesChanged(path, count)`. This could certainly be iterated on for friendliness, but right now it's a step up from just `Started`.

