### PR TITLE
Gating `cachix push` on availablility of signing key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ result
 **/*.rs.bk
 .bash_history
 crates-io.list
+*.rustfmt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,12 @@
 "matrix":
   "include":
   - "before_cache":
-    - >-
-      [ -n "$CACHIX_SIGNING_KEY" ] && cachix push lorri-test < $HOME/push-to-cachix
+    - >
+      if [ -n "$CACHIX_SIGNING_KEY" ]; then
+        cachix push lorri-test < $HOME/push-to-cachix
+      else
+        true
+      fi
     - >-
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/liblorri.rlib"
     - >-
@@ -131,8 +135,12 @@
       \
         >> $HOME/push-to-cachix
   - "before_cache":
-    - >-
-      [ -n "$CACHIX_SIGNING_KEY" ] && cachix push lorri-test < $HOME/push-to-cachix
+    - >
+      if [ -n "$CACHIX_SIGNING_KEY" ]; then
+        cachix push lorri-test < $HOME/push-to-cachix
+      else
+        true
+      fi
     "install":
     - >-
       nix-env -iA cachix -f https://cachix.org/api/v1/install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@
   "include":
   - "before_cache":
     - >-
-      cachix push lorri-test < $HOME/push-to-cachix
+      [ -n $CACHIX_SIGNING_KEY ] && cachix push lorri-test < $HOME/push-to-cachix
     - >-
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/liblorri.rlib"
     - >-
@@ -132,7 +132,7 @@
         >> $HOME/push-to-cachix
   - "before_cache":
     - >-
-      cachix push lorri-test < $HOME/push-to-cachix
+      [ -n $CACHIX_SIGNING_KEY ] && cachix push lorri-test < $HOME/push-to-cachix
     "install":
     - >-
       nix-env -iA cachix -f https://cachix.org/api/v1/install

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@
     - >
       if [ -n "$CACHIX_SIGNING_KEY" ]; then
         cachix push lorri-test < $HOME/push-to-cachix
-      else
-        true
       fi
     - >-
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/liblorri.rlib"
@@ -138,8 +136,6 @@
     - >
       if [ -n "$CACHIX_SIGNING_KEY" ]; then
         cachix push lorri-test < $HOME/push-to-cachix
-      else
-        true
       fi
     "install":
     - >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@
   "include":
   - "before_cache":
     - >-
-      [ -n $CACHIX_SIGNING_KEY ] && cachix push lorri-test < $HOME/push-to-cachix
+      [ -n "$CACHIX_SIGNING_KEY" ] && cachix push lorri-test < $HOME/push-to-cachix
     - >-
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/liblorri.rlib"
     - >-
@@ -132,7 +132,7 @@
         >> $HOME/push-to-cachix
   - "before_cache":
     - >-
-      [ -n $CACHIX_SIGNING_KEY ] && cachix push lorri-test < $HOME/push-to-cachix
+      [ -n "$CACHIX_SIGNING_KEY" ] && cachix push lorri-test < $HOME/push-to-cachix
     "install":
     - >-
       nix-env -iA cachix -f https://cachix.org/api/v1/install

--- a/.travis.yml.nix
+++ b/.travis.yml.nix
@@ -105,7 +105,7 @@ let
         before_cache = [
           # read every store path written by previous phases
           # from the cachix-queue-file file and push to cachix
-          ''cachix push ${cachix-repo} < ${cachix-queue-file}''
+          ''[ -n $CACHIX_SIGNING_KEY ] && cachix push lorri-test < $HOME/push-to-cachix''
         ];
       };
 

--- a/.travis.yml.nix
+++ b/.travis.yml.nix
@@ -105,7 +105,7 @@ let
         before_cache = [
           # read every store path written by previous phases
           # from the cachix-queue-file file and push to cachix
-          ''[ -n $CACHIX_SIGNING_KEY ] && cachix push lorri-test < $HOME/push-to-cachix''
+          ''[ -n "$CACHIX_SIGNING_KEY" ] && cachix push lorri-test < $HOME/push-to-cachix''
         ];
       };
 

--- a/.travis.yml.nix
+++ b/.travis.yml.nix
@@ -108,8 +108,6 @@ let
           ''
           if [ -n "$CACHIX_SIGNING_KEY" ]; then
             cachix push lorri-test < $HOME/push-to-cachix
-          else
-            true
           fi
           ''
         ];

--- a/.travis.yml.nix
+++ b/.travis.yml.nix
@@ -105,7 +105,13 @@ let
         before_cache = [
           # read every store path written by previous phases
           # from the cachix-queue-file file and push to cachix
-          ''[ -n "$CACHIX_SIGNING_KEY" ] && cachix push lorri-test < $HOME/push-to-cachix''
+          ''
+          if [ -n "$CACHIX_SIGNING_KEY" ]; then
+            cachix push lorri-test < $HOME/push-to-cachix
+          else
+            true
+          fi
+          ''
         ];
       };
 


### PR DESCRIPTION
It seems like Travis is withholding the Cachix signing key from PRs from forks (which is appropriate.)

This PR prevents `cachix push` if the signing key isn't available.