### PR TITLE
nix.rs: allow reading stderr output via Rx/Tx

### DIFF
--- a/nix/bogus-nixpkgs/default.nix
+++ b/nix/bogus-nixpkgs/default.nix
@@ -9,7 +9,15 @@ let
     outputHash = builtins.hashString "sha256" name;
   };
 
+  bogusUnstable = builder: name: derivation {
+    inherit name;
+    builder = builder;
+    system = builtins.currentSystem;
+    bust = builtins.currentTime;
+  };
+
   bogusPackage = bogusFO ./builder.sh;
+  bogusUnstablePackage = bogusUnstable ./builder.sh;
 
 in {
   mkShell = { name ? "shell", buildInputs ? [], env ? {} }: derivation
@@ -21,6 +29,8 @@ in {
     });
 
   hello = bogusPackage "hello-1.0.0";
+
+  hello-unstable = bogusUnstablePackage "hello-unstable-1.0.0";
 
   git = bogusPackage "git-1.0.0";
 }

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -542,10 +542,10 @@ impl From<BuildError> for OnePathError {
 #[cfg(test)]
 mod tests {
     use super::CallOpts;
+    use std::env;
     use std::ffi::OsStr;
     use std::path::PathBuf;
     use std::sync::mpsc::channel;
-    use std::env;
 
     #[test]
     fn cmd_arguments_expression() {
@@ -593,23 +593,36 @@ mod tests {
         env::set_var("NIX_PATH", "nixpkgs=./nix/bogus-nixpkgs/");
 
         let (tx, rx) = channel();
-        let _result = CallOpts::expression(r#"
+        let _result = CallOpts::expression(
+            r#"
                   import <nixpkgs> {}
-        "#)
-              .attribute("hello-unstable")
-            .set_stderr_sender(tx)
-            .path()
-            .unwrap()
-            ;
+        "#,
+        )
+        .attribute("hello-unstable")
+        .set_stderr_sender(tx)
+        .path()
+        .unwrap();
 
-        let messages: Vec<String> = rx.iter()
+        let messages: Vec<String> = rx
+            .iter()
             .map(|osstr| osstr.to_string_lossy().into())
             .collect();
 
         println!("messages: {:#?}", messages);
-        assert!(messages.contains(&String::from("these derivations will be built:")), "looking for 'these derivations will be built:'");
-        assert!(messages.iter().any(|m| m.contains("hello-unstable-1.0.0.drv")), "looking for a line like '  /nix/store/...-hello-unstable-1.0.0.drv'");
-        assert!(messages.iter().any(|m| m.contains("building '/nix/store")), "looking for a line like 'building \'/nix/store...'");
+        assert!(
+            messages.contains(&String::from("these derivations will be built:")),
+            "looking for 'these derivations will be built:'"
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.contains("hello-unstable-1.0.0.drv")),
+            "looking for a line like '  /nix/store/...-hello-unstable-1.0.0.drv'"
+        );
+        assert!(
+            messages.iter().any(|m| m.contains("building '/nix/store")),
+            "looking for a line like 'building \'/nix/store...'"
+        );
     }
 
 }

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -364,6 +364,9 @@ impl CallOpts {
         }
     }
 
+    /// Execute a command (presumably a Nix command :)). stderr output
+    /// is passed line-based to the CallOpts' stderr_line_tx receiver.
+    /// Stdout is passed as a BufReader to `stdout_fn`.
     fn execute<T: 'static, S: 'static>(
         &self,
         mut cmd: Command,


### PR DESCRIPTION
Callers can pass a `Sender<OsString>` to CallOpts. Each line of stderr
outpuut from Nix is passed over this channel.