### PR TITLE
(against #117) nix: test on 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
   "depth": !!bool >-
     false
 "language": >-
-  nix
+  minimal
 "matrix":
   "include":
   - "before_cache":
@@ -51,7 +51,7 @@
     "name": >-
       cargo build & linters
     "nix": >-
-      2.2.1
+      2.3.1
     "os": >-
       linux
     "script":
@@ -96,6 +96,17 @@
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/deps/direnv-*"
     - >-
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/incremental/direnv-*"
+    "before_install":
+    - >
+      wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/releases/nix/nix-2.3.1/install
+
+      yes | sh /tmp/nix-install --daemon
+
+      if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+        source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+      elif [ -f ${TRAVIS_HOME}/.nix-profile/etc/profile.d/nix.sh ]; then
+        source source ${TRAVIS_HOME}/.nix-profile/etc/profile.d/nix.sh
+      fi
     "cache":
       "directories":
       - >-
@@ -105,12 +116,8 @@
     "env":
     - >-
       CACHE_NAME=macos
-    "language": >-
-      nix
     "name": >-
       cargo build & linters
-    "nix": >-
-      2.0
     "os": >-
       osx
     "script":
@@ -147,7 +154,7 @@
     "name": >-
       nix-build
     "nix": >-
-      2.2.1
+      2.3.1
     "os": >-
       linux
     "script":
@@ -164,12 +171,19 @@
         lorri self-upgrade local $(pwd)
     - >-
       readlink ./result >> $HOME/push-to-cachix
-  - "language": >-
-      nix
+  - "before_install":
+    - >
+      wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/releases/nix/nix-2.3.1/install
+
+      yes | sh /tmp/nix-install --daemon
+
+      if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+        source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+      elif [ -f ${TRAVIS_HOME}/.nix-profile/etc/profile.d/nix.sh ]; then
+        source source ${TRAVIS_HOME}/.nix-profile/etc/profile.d/nix.sh
+      fi
     "name": >-
       nix-build
-    "nix": >-
-      2.0
     "os": >-
       osx
     "script":

--- a/.travis.yml.nix
+++ b/.travis.yml.nix
@@ -9,13 +9,24 @@ let
     linux = {
       os = "linux";
       language = "nix";
-      nix = "2.2.1";
+      nix = "2.3.1";
     };
 
     macos = {
       os = "osx";
-      language = "nix";
-      nix = "2.0";
+      #language = "nix";
+      #nix = "2.3.1";
+      before_install = [
+        ''
+          wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/releases/nix/nix-2.3.1/install
+          yes | sh /tmp/nix-install --daemon
+          if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+            source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          elif [ -f ''${TRAVIS_HOME}/.nix-profile/etc/profile.d/nix.sh ]; then
+            source source ''${TRAVIS_HOME}/.nix-profile/etc/profile.d/nix.sh
+          fi
+        ''
+      ];
     };
   };
 
@@ -138,7 +149,7 @@ let
     in
     {
       git.depth = false;
-      language = "nix";
+      language = "minimal";
       matrix.include = map mergeShallowConcatLists [
         # Verifying lints on macOS and Linux ensures nix-shell works
         # on both platforms.


### PR DESCRIPTION
The older version of Nix on darwin (2.0) had a bug where it wouldn't
interpret a symlink as a `.drv`.

The upstream Travis support for newer Nixes on Darwin is a bit broken,
so this is working around that for now.

The default language changes to `minimal`, but the Linux version
overrides it to `nix`.