### PR TITLE
Add human-panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,26 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "backtrace"
+version = "0.3.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bincode"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +218,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "human-panic"
+version = "1.0.1"
+source = "git+https://github.com/rust-cli/human-panic.git?rev=70db9489#70db948973a746418e3a23434fe48fe45d3c9866"
+dependencies = [
+ "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "os_type 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "humantime"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +315,7 @@ dependencies = [
  "directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "human-panic 1.0.1 (git+https://github.com/rust-cli/human-panic.git?rev=70db9489)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "md5 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -390,6 +425,14 @@ dependencies = [
 name = "num-traits"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "os_type"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -589,6 +632,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +808,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ucd-util"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +839,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "utf8-ranges"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "uuid"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "vec1"
@@ -878,6 +942,8 @@ dependencies = [
 "checksum atomicwrites 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c4e1aa99513c90202b4b04cfbe3c9d51dd914f2e26215a4caa76574b00bb6393"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
+"checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
+"checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum bincode 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "959c8e54c1ad412ffeeb95f05a9cade02d2d40a7b3c2f852d3353148f4beff35"
 "checksum bit-set 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f1efcc46c18245a69c38fcc5cc650f16d3a59d034f3106e9ed63748f695730a"
 "checksum bit-vec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4440d5cb623bb7390ae27fec0bb6c61111969860f8e3ae198bfa0663645e67cf"
@@ -899,6 +965,7 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum human-panic 1.0.1 (git+https://github.com/rust-cli/human-panic.git?rev=70db9489)" = "<none>"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum inotify 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40b54539f3910d6f84fbf9a643efd6e3aa6e4f001426c0329576128255994718"
 "checksum inotify-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
@@ -918,6 +985,7 @@ dependencies = [
 "checksum nix 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0d10caafde29a846a82ae0af70414e4643e072993441033b2c93217957e2f867"
 "checksum notify 4.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9cc7ed2bd4b7edad3ee93b659c38e53dabb619f7274e127a0fab054ad2bb998d"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum os_type 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7edc011af0ae98b7f88cf7e4a83b70a54a75d2b8cb013d6efd02e5956207e9eb"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum proptest 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea66c78d75f2c6e9f304269eaef90899798daecc69f1a625d5a3dd793ff3522"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
@@ -939,6 +1007,7 @@ dependencies = [
 "checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
 "checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusty-fork 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9591f190d2852720b679c21f66ad929f9f1d7bb09d1193c26167586029d8489c"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
@@ -960,11 +1029,13 @@ dependencies = [
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vec1 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "346d78889999f421a67bcbb20e06c86bf7b27a85448eb629e34ff7574b979eb5"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -6,6 +6,55 @@ let inherit (lib.lists) fold;
 in
 rec {
   crates = cratesIO // rec {
+# human-panic-1.0.1
+
+    crates.human_panic."1.0.1" = deps: { features?(features_.human_panic."1.0.1" deps {}) }: buildRustCrate {
+      crateName = "human-panic";
+      version = "1.0.1";
+      description = "Panic messages for humans";
+      authors = [ "Yoshua Wuyts <yoshuawuyts@gmail.com>" "Pascal Hertleif <killercup@gmail.com>" "Katharina Fey <kookie@spacekookie.de>" ];
+      edition = "2018";
+      src = fetchgit {
+         url = "https://github.com/rust-cli/human-panic.git";
+         rev = "70db948973a746418e3a23434fe48fe45d3c9866";
+         sha256 = "0yznxvgxl5nka75p4bh1pf8ab0c3mfqwihp7lcl0vbiv2yli7nkv";
+         fetchSubmodules = false;
+      };
+      dependencies = mapFeatures features ([
+        (cratesIO.crates."backtrace"."${deps."human_panic"."1.0.1"."backtrace"}" deps)
+        (cratesIO.crates."os_type"."${deps."human_panic"."1.0.1"."os_type"}" deps)
+        (cratesIO.crates."serde"."${deps."human_panic"."1.0.1"."serde"}" deps)
+        (cratesIO.crates."serde_derive"."${deps."human_panic"."1.0.1"."serde_derive"}" deps)
+        (cratesIO.crates."termcolor"."${deps."human_panic"."1.0.1"."termcolor"}" deps)
+        (cratesIO.crates."toml"."${deps."human_panic"."1.0.1"."toml"}" deps)
+        (cratesIO.crates."uuid"."${deps."human_panic"."1.0.1"."uuid"}" deps)
+      ]);
+      features = mkFeatures (features."human_panic"."1.0.1" or {});
+    };
+    features_.human_panic."1.0.1" = deps: f: updateFeatures f (rec {
+      backtrace."${deps.human_panic."1.0.1".backtrace}".default = true;
+      human_panic."1.0.1".default = (f.human_panic."1.0.1".default or true);
+      os_type."${deps.human_panic."1.0.1".os_type}".default = true;
+      serde."${deps.human_panic."1.0.1".serde}".default = true;
+      serde_derive."${deps.human_panic."1.0.1".serde_derive}".default = true;
+      termcolor."${deps.human_panic."1.0.1".termcolor}".default = true;
+      toml."${deps.human_panic."1.0.1".toml}".default = true;
+      uuid = fold recursiveUpdate {} [
+        { "${deps.human_panic."1.0.1".uuid}"."v4" = true; }
+        { "${deps.human_panic."1.0.1".uuid}".default = (f.uuid."${deps.human_panic."1.0.1".uuid}".default or false); }
+      ];
+    }) [
+      (cratesIO.features_.backtrace."${deps."human_panic"."1.0.1"."backtrace"}" deps)
+      (cratesIO.features_.os_type."${deps."human_panic"."1.0.1"."os_type"}" deps)
+      (cratesIO.features_.serde."${deps."human_panic"."1.0.1"."serde"}" deps)
+      (cratesIO.features_.serde_derive."${deps."human_panic"."1.0.1"."serde_derive"}" deps)
+      (cratesIO.features_.termcolor."${deps."human_panic"."1.0.1"."termcolor"}" deps)
+      (cratesIO.features_.toml."${deps."human_panic"."1.0.1"."toml"}" deps)
+      (cratesIO.features_.uuid."${deps."human_panic"."1.0.1"."uuid"}" deps)
+    ];
+
+
+# end
 # lorri-0.1.0
 
     crates.lorri."0.1.0" = deps: { features?(features_.lorri."0.1.0" deps {}) }: buildRustCrate {
@@ -19,6 +68,7 @@ rec {
         (cratesIO.crates."directories"."${deps."lorri"."0.1.0"."directories"}" deps)
         (cratesIO.crates."env_logger"."${deps."lorri"."0.1.0"."env_logger"}" deps)
         (cratesIO.crates."futures"."${deps."lorri"."0.1.0"."futures"}" deps)
+        (crates."human_panic"."${deps."lorri"."0.1.0"."human_panic"}" deps)
         (cratesIO.crates."lazy_static"."${deps."lorri"."0.1.0"."lazy_static"}" deps)
         (cratesIO.crates."log"."${deps."lorri"."0.1.0"."log"}" deps)
         (cratesIO.crates."md5"."${deps."lorri"."0.1.0"."md5"}" deps)
@@ -40,6 +90,7 @@ rec {
       directories."${deps.lorri."0.1.0".directories}".default = true;
       env_logger."${deps.lorri."0.1.0".env_logger}".default = true;
       futures."${deps.lorri."0.1.0".futures}".default = true;
+      human_panic."${deps.lorri."0.1.0".human_panic}".default = true;
       lazy_static."${deps.lorri."0.1.0".lazy_static}".default = true;
       log."${deps.lorri."0.1.0".log}".default = true;
       lorri."0.1.0".default = (f.lorri."0.1.0".default or true);
@@ -60,6 +111,7 @@ rec {
       (cratesIO.features_.directories."${deps."lorri"."0.1.0"."directories"}" deps)
       (cratesIO.features_.env_logger."${deps."lorri"."0.1.0"."env_logger"}" deps)
       (cratesIO.features_.futures."${deps."lorri"."0.1.0"."futures"}" deps)
+      (features_.human_panic."${deps."lorri"."0.1.0"."human_panic"}" deps)
       (cratesIO.features_.lazy_static."${deps."lorri"."0.1.0"."lazy_static"}" deps)
       (cratesIO.features_.log."${deps."lorri"."0.1.0"."log"}" deps)
       (cratesIO.features_.md5."${deps."lorri"."0.1.0"."md5"}" deps)
@@ -99,6 +151,16 @@ rec {
     winapi = "0.3.6";
   };
   deps.autocfg."0.1.2" = {};
+  deps.backtrace."0.3.38" = {
+    backtrace_sys = "0.1.31";
+    cfg_if = "0.1.6";
+    libc = "0.2.55";
+    rustc_demangle = "0.1.16";
+  };
+  deps.backtrace_sys."0.1.31" = {
+    libc = "0.2.55";
+    cc = "1.0.37";
+  };
   deps.bincode."1.1.3" = {
     byteorder = "1.3.1";
     serde = "1.0.88";
@@ -160,6 +222,15 @@ rec {
   deps.heck."0.3.1" = {
     unicode_segmentation = "1.2.1";
   };
+  deps.human_panic."1.0.1" = {
+    backtrace = "0.3.38";
+    os_type = "2.2.0";
+    serde = "1.0.88";
+    serde_derive = "1.0.88";
+    termcolor = "1.0.4";
+    toml = "0.4.10";
+    uuid = "0.7.4";
+  };
   deps.humantime."1.2.0" = {
     quick_error = "1.2.2";
   };
@@ -194,6 +265,7 @@ rec {
     directories = "1.0.2";
     env_logger = "0.6.0";
     futures = "0.1.25";
+    human_panic = "1.0.1";
     lazy_static = "1.2.0";
     log = "0.4.6";
     md5 = "0.6.1";
@@ -260,6 +332,9 @@ rec {
     winapi = "0.3.6";
   };
   deps.num_traits."0.2.6" = {};
+  deps.os_type."2.2.0" = {
+    regex = "1.1.0";
+  };
   deps.proc_macro2."0.4.27" = {
     unicode_xid = "0.1.0";
   };
@@ -355,6 +430,7 @@ rec {
   deps.remove_dir_all."0.5.1" = {
     winapi = "0.3.6";
   };
+  deps.rustc_demangle."0.1.16" = {};
   deps.rustc_version."0.2.3" = {
     semver = "0.9.0";
   };
@@ -427,11 +503,17 @@ rec {
   deps.thread_local."0.3.6" = {
     lazy_static = "1.2.0";
   };
+  deps.toml."0.4.10" = {
+    serde = "1.0.88";
+  };
   deps.ucd_util."0.1.3" = {};
   deps.unicode_segmentation."1.2.1" = {};
   deps.unicode_width."0.1.5" = {};
   deps.unicode_xid."0.1.0" = {};
   deps.utf8_ranges."1.0.2" = {};
+  deps.uuid."0.7.4" = {
+    rand = "0.6.5";
+  };
   deps.vec1."1.1.0" = {};
   deps.vec_map."0.8.1" = {};
   deps.void."1.0.2" = {};

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = [
   "Graham Christensen <graham.christensen@target.com>",
 ]
+homepage = "https://github.com/target/lorri"
 license = "Apache-2.0"
 
 [dependencies]
@@ -25,3 +26,6 @@ atomicwrites = "0.2.3"
 vec1 = "1.1.0"
 proptest = "0.9.1"
 nix = "0.14.0"
+# pinned to a git commit pending v2.0 release
+# see: https://github.com/rust-cli/human-panic/issues/46
+human-panic = { git = "https://github.com/rust-cli/human-panic.git", rev = "70db9489" }

--- a/default.nix
+++ b/default.nix
@@ -17,6 +17,11 @@
       RUN_TIME_CLOSURE = pkgs.callPackage ./nix/runtime.nix {};
       NIX_PATH = "nixpkgs=${./nix/bogus-nixpkgs}";
 
+      # required by human-panic, because carnix doesn’t
+      # set the cargo environment variables correctly.
+      # see https://doc.rust-lang.org/cargo/reference/environment-variables.html
+      homepage = "https://github.com/target/lorri";
+
       preConfigure = ''
         . ${./nix/pre-check.sh}
 

--- a/nix/carnix/crates-io.nix
+++ b/nix/carnix/crates-io.nix
@@ -142,6 +142,161 @@ rec {
 
 
 # end
+# backtrace-0.3.38
+
+  crates.backtrace."0.3.38" = deps: { features?(features_.backtrace."0.3.38" deps {}) }: buildRustCrate {
+    crateName = "backtrace";
+    version = "0.3.38";
+    description = "A library to acquire a stack trace (backtrace) at runtime in a Rust program.\n";
+    authors = [ "The Rust Project Developers" ];
+    edition = "2018";
+    sha256 = "0k41sw74xd19s9lsqab1rf94wi8l7ppfarib8hpd0y7q2iym5j41";
+    dependencies = mapFeatures features ([
+      (crates."cfg_if"."${deps."backtrace"."0.3.38"."cfg_if"}" deps)
+      (crates."libc"."${deps."backtrace"."0.3.38"."libc"}" deps)
+      (crates."rustc_demangle"."${deps."backtrace"."0.3.38"."rustc_demangle"}" deps)
+    ]
+      ++ (if features.backtrace."0.3.38".backtrace-sys or false then [ (crates.backtrace_sys."${deps."backtrace"."0.3.38".backtrace_sys}" deps) ] else []))
+      ++ (if kernel == "windows" then mapFeatures features ([
+]) else []);
+    features = mkFeatures (features."backtrace"."0.3.38" or {});
+  };
+  features_.backtrace."0.3.38" = deps: f: updateFeatures f (rec {
+    backtrace = fold recursiveUpdate {} [
+      { "0.3.38"."addr2line" =
+        (f.backtrace."0.3.38"."addr2line" or false) ||
+        (f.backtrace."0.3.38".gimli-symbolize or false) ||
+        (backtrace."0.3.38"."gimli-symbolize" or false); }
+      { "0.3.38"."backtrace-sys" =
+        (f.backtrace."0.3.38"."backtrace-sys" or false) ||
+        (f.backtrace."0.3.38".libbacktrace or false) ||
+        (backtrace."0.3.38"."libbacktrace" or false); }
+      { "0.3.38"."compiler_builtins" =
+        (f.backtrace."0.3.38"."compiler_builtins" or false) ||
+        (f.backtrace."0.3.38".rustc-dep-of-std or false) ||
+        (backtrace."0.3.38"."rustc-dep-of-std" or false); }
+      { "0.3.38"."core" =
+        (f.backtrace."0.3.38"."core" or false) ||
+        (f.backtrace."0.3.38".rustc-dep-of-std or false) ||
+        (backtrace."0.3.38"."rustc-dep-of-std" or false); }
+      { "0.3.38"."dbghelp" =
+        (f.backtrace."0.3.38"."dbghelp" or false) ||
+        (f.backtrace."0.3.38".default or false) ||
+        (backtrace."0.3.38"."default" or false); }
+      { "0.3.38"."dladdr" =
+        (f.backtrace."0.3.38"."dladdr" or false) ||
+        (f.backtrace."0.3.38".default or false) ||
+        (backtrace."0.3.38"."default" or false); }
+      { "0.3.38"."findshlibs" =
+        (f.backtrace."0.3.38"."findshlibs" or false) ||
+        (f.backtrace."0.3.38".gimli-symbolize or false) ||
+        (backtrace."0.3.38"."gimli-symbolize" or false); }
+      { "0.3.38"."goblin" =
+        (f.backtrace."0.3.38"."goblin" or false) ||
+        (f.backtrace."0.3.38".gimli-symbolize or false) ||
+        (backtrace."0.3.38"."gimli-symbolize" or false); }
+      { "0.3.38"."libbacktrace" =
+        (f.backtrace."0.3.38"."libbacktrace" or false) ||
+        (f.backtrace."0.3.38".default or false) ||
+        (backtrace."0.3.38"."default" or false); }
+      { "0.3.38"."libunwind" =
+        (f.backtrace."0.3.38"."libunwind" or false) ||
+        (f.backtrace."0.3.38".default or false) ||
+        (backtrace."0.3.38"."default" or false); }
+      { "0.3.38"."memmap" =
+        (f.backtrace."0.3.38"."memmap" or false) ||
+        (f.backtrace."0.3.38".gimli-symbolize or false) ||
+        (backtrace."0.3.38"."gimli-symbolize" or false); }
+      { "0.3.38"."rustc-serialize" =
+        (f.backtrace."0.3.38"."rustc-serialize" or false) ||
+        (f.backtrace."0.3.38".serialize-rustc or false) ||
+        (backtrace."0.3.38"."serialize-rustc" or false); }
+      { "0.3.38"."serde" =
+        (f.backtrace."0.3.38"."serde" or false) ||
+        (f.backtrace."0.3.38".serialize-serde or false) ||
+        (backtrace."0.3.38"."serialize-serde" or false); }
+      { "0.3.38"."std" =
+        (f.backtrace."0.3.38"."std" or false) ||
+        (f.backtrace."0.3.38".default or false) ||
+        (backtrace."0.3.38"."default" or false); }
+      { "0.3.38".default = (f.backtrace."0.3.38".default or true); }
+    ];
+    backtrace_sys = fold recursiveUpdate {} [
+      { "${deps.backtrace."0.3.38".backtrace_sys}"."rustc-dep-of-std" =
+        (f.backtrace_sys."${deps.backtrace."0.3.38".backtrace_sys}"."rustc-dep-of-std" or false) ||
+        (backtrace."0.3.38"."rustc-dep-of-std" or false) ||
+        (f."backtrace"."0.3.38"."rustc-dep-of-std" or false); }
+      { "${deps.backtrace."0.3.38".backtrace_sys}".default = true; }
+    ];
+    cfg_if = fold recursiveUpdate {} [
+      { "${deps.backtrace."0.3.38".cfg_if}"."rustc-dep-of-std" =
+        (f.cfg_if."${deps.backtrace."0.3.38".cfg_if}"."rustc-dep-of-std" or false) ||
+        (backtrace."0.3.38"."rustc-dep-of-std" or false) ||
+        (f."backtrace"."0.3.38"."rustc-dep-of-std" or false); }
+      { "${deps.backtrace."0.3.38".cfg_if}".default = true; }
+    ];
+    libc = fold recursiveUpdate {} [
+      { "${deps.backtrace."0.3.38".libc}"."rustc-dep-of-std" =
+        (f.libc."${deps.backtrace."0.3.38".libc}"."rustc-dep-of-std" or false) ||
+        (backtrace."0.3.38"."rustc-dep-of-std" or false) ||
+        (f."backtrace"."0.3.38"."rustc-dep-of-std" or false); }
+      { "${deps.backtrace."0.3.38".libc}".default = (f.libc."${deps.backtrace."0.3.38".libc}".default or false); }
+    ];
+    rustc_demangle = fold recursiveUpdate {} [
+      { "${deps.backtrace."0.3.38".rustc_demangle}"."rustc-dep-of-std" =
+        (f.rustc_demangle."${deps.backtrace."0.3.38".rustc_demangle}"."rustc-dep-of-std" or false) ||
+        (backtrace."0.3.38"."rustc-dep-of-std" or false) ||
+        (f."backtrace"."0.3.38"."rustc-dep-of-std" or false); }
+      { "${deps.backtrace."0.3.38".rustc_demangle}".default = true; }
+    ];
+  }) [
+    (features_.backtrace_sys."${deps."backtrace"."0.3.38"."backtrace_sys"}" deps)
+    (features_.cfg_if."${deps."backtrace"."0.3.38"."cfg_if"}" deps)
+    (features_.libc."${deps."backtrace"."0.3.38"."libc"}" deps)
+    (features_.rustc_demangle."${deps."backtrace"."0.3.38"."rustc_demangle"}" deps)
+  ];
+
+
+# end
+# backtrace-sys-0.1.31
+
+  crates.backtrace_sys."0.1.31" = deps: { features?(features_.backtrace_sys."0.1.31" deps {}) }: buildRustCrate {
+    crateName = "backtrace-sys";
+    version = "0.1.31";
+    description = "Bindings to the libbacktrace gcc library\n";
+    authors = [ "Alex Crichton <alex@alexcrichton.com>" ];
+    sha256 = "1gv41cypl4y5r32za4gx2fks43d76sp1r3yb5524i4gs50lrkypv";
+    build = "build.rs";
+    dependencies = mapFeatures features ([
+      (crates."libc"."${deps."backtrace_sys"."0.1.31"."libc"}" deps)
+    ]);
+
+    buildDependencies = mapFeatures features ([
+      (crates."cc"."${deps."backtrace_sys"."0.1.31"."cc"}" deps)
+    ]);
+    features = mkFeatures (features."backtrace_sys"."0.1.31" or {});
+  };
+  features_.backtrace_sys."0.1.31" = deps: f: updateFeatures f (rec {
+    backtrace_sys = fold recursiveUpdate {} [
+      { "0.1.31"."compiler_builtins" =
+        (f.backtrace_sys."0.1.31"."compiler_builtins" or false) ||
+        (f.backtrace_sys."0.1.31".rustc-dep-of-std or false) ||
+        (backtrace_sys."0.1.31"."rustc-dep-of-std" or false); }
+      { "0.1.31"."core" =
+        (f.backtrace_sys."0.1.31"."core" or false) ||
+        (f.backtrace_sys."0.1.31".rustc-dep-of-std or false) ||
+        (backtrace_sys."0.1.31"."rustc-dep-of-std" or false); }
+      { "0.1.31".default = (f.backtrace_sys."0.1.31".default or true); }
+    ];
+    cc."${deps.backtrace_sys."0.1.31".cc}".default = true;
+    libc."${deps.backtrace_sys."0.1.31".libc}".default = (f.libc."${deps.backtrace_sys."0.1.31".libc}".default or false);
+  }) [
+    (features_.libc."${deps."backtrace_sys"."0.1.31"."libc"}" deps)
+    (features_.cc."${deps."backtrace_sys"."0.1.31"."cc"}" deps)
+  ];
+
+
+# end
 # bincode-1.1.3
 
   crates.bincode."1.1.3" = deps: { features?(features_.bincode."1.1.3" deps {}) }: buildRustCrate {
@@ -1340,6 +1495,27 @@ rec {
 
 
 # end
+# os_type-2.2.0
+
+  crates.os_type."2.2.0" = deps: { features?(features_.os_type."2.2.0" deps {}) }: buildRustCrate {
+    crateName = "os_type";
+    version = "2.2.0";
+    description = "Detect the operating system type";
+    authors = [ "Jan Schulte <hello@unexpected-co.de>" ];
+    sha256 = "100ldg1vv0pxrb9s83vb4awvczbg8iy1by6vx6zl8vpdnr8n2ghg";
+    dependencies = mapFeatures features ([
+      (crates."regex"."${deps."os_type"."2.2.0"."regex"}" deps)
+    ]);
+  };
+  features_.os_type."2.2.0" = deps: f: updateFeatures f (rec {
+    os_type."2.2.0".default = (f.os_type."2.2.0".default or true);
+    regex."${deps.os_type."2.2.0".regex}".default = true;
+  }) [
+    (features_.regex."${deps."os_type"."2.2.0"."regex"}" deps)
+  ];
+
+
+# end
 # proc-macro2-0.4.27
 
   crates.proc_macro2."0.4.27" = deps: { features?(features_.proc_macro2."0.4.27" deps {}) }: buildRustCrate {
@@ -2229,6 +2405,34 @@ rec {
 
 
 # end
+# rustc-demangle-0.1.16
+
+  crates.rustc_demangle."0.1.16" = deps: { features?(features_.rustc_demangle."0.1.16" deps {}) }: buildRustCrate {
+    crateName = "rustc-demangle";
+    version = "0.1.16";
+    description = "Rust compiler symbol demangling.\n";
+    authors = [ "Alex Crichton <alex@alexcrichton.com>" ];
+    sha256 = "0zmn448d0f898ahfkz7cir0fi0vk84dabjpw84mk6a1r6nf9vzmi";
+    dependencies = mapFeatures features ([
+]);
+    features = mkFeatures (features."rustc_demangle"."0.1.16" or {});
+  };
+  features_.rustc_demangle."0.1.16" = deps: f: updateFeatures f (rec {
+    rustc_demangle = fold recursiveUpdate {} [
+      { "0.1.16"."compiler_builtins" =
+        (f.rustc_demangle."0.1.16"."compiler_builtins" or false) ||
+        (f.rustc_demangle."0.1.16".rustc-dep-of-std or false) ||
+        (rustc_demangle."0.1.16"."rustc-dep-of-std" or false); }
+      { "0.1.16"."core" =
+        (f.rustc_demangle."0.1.16"."core" or false) ||
+        (f.rustc_demangle."0.1.16".rustc-dep-of-std or false) ||
+        (rustc_demangle."0.1.16"."rustc-dep-of-std" or false); }
+      { "0.1.16".default = (f.rustc_demangle."0.1.16".default or true); }
+    ];
+  }) [];
+
+
+# end
 # rustc_version-0.2.3
 
   crates.rustc_version."0.2.3" = deps: { features?(features_.rustc_version."0.2.3" deps {}) }: buildRustCrate {
@@ -2869,6 +3073,27 @@ rec {
 
 
 # end
+# toml-0.4.10
+
+  crates.toml."0.4.10" = deps: { features?(features_.toml."0.4.10" deps {}) }: buildRustCrate {
+    crateName = "toml";
+    version = "0.4.10";
+    description = "A native Rust encoder and decoder of TOML-formatted files and streams. Provides\nimplementations of the standard Serialize/Deserialize traits for TOML data to\nfacilitate deserializing and serializing Rust structures.\n";
+    authors = [ "Alex Crichton <alex@alexcrichton.com>" ];
+    sha256 = "0fs4kxl86w3kmgwcgcv23nk79zagayz1spg281r83w0ywf88d6f1";
+    dependencies = mapFeatures features ([
+      (crates."serde"."${deps."toml"."0.4.10"."serde"}" deps)
+    ]);
+  };
+  features_.toml."0.4.10" = deps: f: updateFeatures f (rec {
+    serde."${deps.toml."0.4.10".serde}".default = true;
+    toml."0.4.10".default = (f.toml."0.4.10".default or true);
+  }) [
+    (features_.serde."${deps."toml"."0.4.10"."serde"}" deps)
+  ];
+
+
+# end
 # ucd-util-0.1.3
 
   crates.ucd_util."0.1.3" = deps: { features?(features_.ucd_util."0.1.3" deps {}) }: buildRustCrate {
@@ -2944,6 +3169,70 @@ rec {
   features_.utf8_ranges."1.0.2" = deps: f: updateFeatures f (rec {
     utf8_ranges."1.0.2".default = (f.utf8_ranges."1.0.2".default or true);
   }) [];
+
+
+# end
+# uuid-0.7.4
+
+  crates.uuid."0.7.4" = deps: { features?(features_.uuid."0.7.4" deps {}) }: buildRustCrate {
+    crateName = "uuid";
+    version = "0.7.4";
+    description = "A library to generate and parse UUIDs.";
+    authors = [ "Ashley Mannix<ashleymannix@live.com.au>" "Christopher Armstrong" "Dylan DPC<dylan.dpc@gmail.com>" "Hunar Roop Kahlon<hunar.roop@gmail.com>" ];
+    sha256 = "1kzjah6i8vf51hrla6qnplymaqx2fadhhlnbvgivgld311lqyz9m";
+    dependencies = mapFeatures features ([
+    ]
+      ++ (if features.uuid."0.7.4".rand or false then [ (crates.rand."${deps."uuid"."0.7.4".rand}" deps) ] else []))
+      ++ (if kernel == "windows" then mapFeatures features ([
+]) else []);
+    features = mkFeatures (features."uuid"."0.7.4" or {});
+  };
+  features_.uuid."0.7.4" = deps: f: updateFeatures f (rec {
+    rand = fold recursiveUpdate {} [
+      { "${deps.uuid."0.7.4".rand}"."stdweb" =
+        (f.rand."${deps.uuid."0.7.4".rand}"."stdweb" or false) ||
+        (uuid."0.7.4"."stdweb" or false) ||
+        (f."uuid"."0.7.4"."stdweb" or false); }
+      { "${deps.uuid."0.7.4".rand}"."wasm-bindgen" =
+        (f.rand."${deps.uuid."0.7.4".rand}"."wasm-bindgen" or false) ||
+        (uuid."0.7.4"."wasm-bindgen" or false) ||
+        (f."uuid"."0.7.4"."wasm-bindgen" or false); }
+      { "${deps.uuid."0.7.4".rand}".default = true; }
+    ];
+    uuid = fold recursiveUpdate {} [
+      { "0.7.4"."byteorder" =
+        (f.uuid."0.7.4"."byteorder" or false) ||
+        (f.uuid."0.7.4".u128 or false) ||
+        (uuid."0.7.4"."u128" or false); }
+      { "0.7.4"."md5" =
+        (f.uuid."0.7.4"."md5" or false) ||
+        (f.uuid."0.7.4".v3 or false) ||
+        (uuid."0.7.4"."v3" or false); }
+      { "0.7.4"."nightly" =
+        (f.uuid."0.7.4"."nightly" or false) ||
+        (f.uuid."0.7.4".const_fn or false) ||
+        (uuid."0.7.4"."const_fn" or false); }
+      { "0.7.4"."rand" =
+        (f.uuid."0.7.4"."rand" or false) ||
+        (f.uuid."0.7.4".v4 or false) ||
+        (uuid."0.7.4"."v4" or false); }
+      { "0.7.4"."sha1" =
+        (f.uuid."0.7.4"."sha1" or false) ||
+        (f.uuid."0.7.4".v5 or false) ||
+        (uuid."0.7.4"."v5" or false); }
+      { "0.7.4"."std" =
+        (f.uuid."0.7.4"."std" or false) ||
+        (f.uuid."0.7.4".default or false) ||
+        (uuid."0.7.4"."default" or false); }
+      { "0.7.4"."winapi" =
+        (f.uuid."0.7.4"."winapi" or false) ||
+        (f.uuid."0.7.4".guid or false) ||
+        (uuid."0.7.4"."guid" or false); }
+      { "0.7.4".default = (f.uuid."0.7.4".default or true); }
+    ];
+  }) [
+    (features_.rand."${deps."uuid"."0.7.4"."rand"}" deps)
+  ];
 
 
 # end

--- a/shell.nix
+++ b/shell.nix
@@ -24,6 +24,7 @@ pkgs.mkShell rec {
     pkgs.direnv
     pkgs.shellcheck
     pkgs.carnix
+    pkgs.nix-prefetch-git
   ] ++
   pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [
     pkgs.darwin.Security

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ extern crate lorri;
 extern crate structopt;
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate human_panic;
 
 use lorri::constants;
 use lorri::locate_file;
@@ -17,6 +19,8 @@ const TRIVIAL_SHELL_SRC: &str = include_str!("./trivial-shell.nix");
 const DEFAULT_ENVRC: &str = "eval \"$(lorri direnv)\"";
 
 fn main() {
+    setup_panic!();
+
     let exit = |result: OpResult| match result {
         Err(err) => {
             eprintln!("{}", err.message());


### PR DESCRIPTION
Add human-panic crate which provides a handler for catching panics and
providing a more human friendly message including contact information
and where to submit bugs as directed by Cargo.toml.

Current provided as pinned to a git commit pending a 2.0 release of
human-panic.

NOTE: In order to get the panic message to appear the binary must both
be a release target and the RUST_BACKTRACE environment variable must be
unset for it to appear. Setting RUST_BACKTRACE to 0 or similar will give
you a regular panic without a backtrace but will not display this
message.

Example panic output from panicking immediately after setup:

```
Well, this is embarrassing.

lorri had a problem and crashed. To help us diagnose the problem you can send us a crash report.

We have generated a report file at "/run/user/1000/report-eb81bb42-18a3-4be5-8e45-3143269d8274.toml". Submit an issue or email with the subject of "lorri Crash Report" and include the report as an attachment.

- Homepage: https://github.com/target/lorri
- Authors: Graham Christensen <graham.christensen@target.com>

We take privacy seriously, and do not perform any automated error collection. In order to improve the software, we rely on people to submit reports.

Thank you kindly!
```

Example file content:

```
name = 'lorri'
operating_system = 'unix:Unknown'
crate_version = '0.1.0'
explanation = '''
Cause: explicit panic. Panic occurred in file 'src/main.rs' at line 23
'''
cause = 'Error cause could not be determined by the application.'
method = 'Panic'
backtrace = '''

   0: 0x5611a588540a - __rust_maybe_catch_panic
                at src/libpanic_unwind/lib.rs:87
   1: 0x5611a587ef6d - try<i32,closure>
                at src/libstd/panicking.rs:272
                 - catch_unwind<closure,i32>
                at src/libstd/panic.rs:388
                 - lang_start_internal
                at src/libstd/rt.rs:48
   2: 0x5611a57b7cf2 - main
   3: 0x7f7c6bf79b8e - __libc_start_main
   4: 0x5611a57b441a - _start
   5:        0x0 - <unknown>'''
```