### PR TITLE
Error type refactoring

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use lorri::locate_file;
 use lorri::NixFile;
 
 use lorri::cli::{Arguments, Command};
-use lorri::ops::{daemon, direnv, info, init, ping, upgrade, watch, err, ExitError, OpResult};
+use lorri::ops::{daemon, direnv, err, info, init, ping, upgrade, watch, ExitError, OpResult};
 use lorri::project::Project;
 use std::path::PathBuf;
 use structopt::StructOpt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use lorri::locate_file;
 use lorri::NixFile;
 
 use lorri::cli::{Arguments, Command};
-use lorri::ops::{daemon, direnv, info, init, ping, upgrade, watch, ExitError, OpResult};
+use lorri::ops::{daemon, direnv, info, init, ping, upgrade, watch, err, ExitError, OpResult};
 use lorri::project::Project;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -58,7 +58,7 @@ fn get_shell_nix(shellfile: &PathBuf) -> Result<NixFile, ExitError> {
 
 fn create_project(paths: &constants::Paths, shell_nix: NixFile) -> Result<Project, ExitError> {
     Project::new(shell_nix, &paths.gc_root_dir(), paths.cas_store().clone())
-        .or_else(|_| Err(ExitError::errmsg("Could not set up project paths")))
+        .or_else(|_| err(1, "Could not set up project paths"))
 }
 
 /// Run the main function of the relevant command.

--- a/src/ops/direnv/mod.rs
+++ b/src/ops/direnv/mod.rs
@@ -3,7 +3,7 @@
 mod version;
 
 use self::version::{DirenvVersion, MIN_DIRENV_VERSION};
-use crate::ops::{ok, ok_msg, ExitError, OpResult};
+use crate::ops::{ok, ok_msg, err, ExitError, OpResult};
 use crate::project::roots::Roots;
 use crate::project::Project;
 use crate::socket::communicate::client;
@@ -90,10 +90,10 @@ fn check_direnv_version() -> OpResult {
         .and_then(|utf| utf.trim_end().parse::<DirenvVersion>())
         .map_err(|()| ExitError::errmsg("Could not figure out the current `direnv` version (parse error)"))?;
     if version < MIN_DIRENV_VERSION {
-        Err(ExitError::errmsg(format!(
+        err(1, format!(
             "`direnv` is version {}, but >= {} is required for lorri to function",
             version, MIN_DIRENV_VERSION
-        )))
+        ))
     } else {
         ok()
     }

--- a/src/ops/direnv/mod.rs
+++ b/src/ops/direnv/mod.rs
@@ -3,7 +3,7 @@
 mod version;
 
 use self::version::{DirenvVersion, MIN_DIRENV_VERSION};
-use crate::ops::{ok, ok_msg, err, ExitError, OpResult};
+use crate::ops::{err, ok, ok_msg, ExitError, OpResult};
 use crate::project::roots::Roots;
 use crate::project::Project;
 use crate::socket::communicate::client;
@@ -88,12 +88,17 @@ fn check_direnv_version() -> OpResult {
     let version = std::str::from_utf8(&out.stdout)
         .map_err(|_| ())
         .and_then(|utf| utf.trim_end().parse::<DirenvVersion>())
-        .map_err(|()| ExitError::errmsg("Could not figure out the current `direnv` version (parse error)"))?;
+        .map_err(|()| {
+            ExitError::errmsg("Could not figure out the current `direnv` version (parse error)")
+        })?;
     if version < MIN_DIRENV_VERSION {
-        err(1, format!(
-            "`direnv` is version {}, but >= {} is required for lorri to function",
-            version, MIN_DIRENV_VERSION
-        ))
+        err(
+            1,
+            format!(
+                "`direnv` is version {}, but >= {} is required for lorri to function",
+                version, MIN_DIRENV_VERSION
+            ),
+        )
     } else {
         ok()
     }
@@ -107,9 +112,13 @@ where
     F: FnOnce(Command) -> std::io::Result<T>,
 {
     let res = cmd(Command::new(executable));
-    res.map_err(|a| ExitError::errmsg( // TODO: other exit code for missing executable?
-             match a.kind() {
+    res.map_err(|a| {
+        ExitError::errmsg(
+            // TODO: other exit code for missing executable?
+            match a.kind() {
                 std::io::ErrorKind::NotFound => format!("`{}`: executable not found", executable),
                 _ => format!("Could not start `{}`: {}", executable, a),
-            }))
+            },
+        )
+    })
 }

--- a/src/ops/direnv/mod.rs
+++ b/src/ops/direnv/mod.rs
@@ -88,10 +88,7 @@ fn check_direnv_version() -> OpResult {
     let version = std::str::from_utf8(&out.stdout)
         .map_err(|_| ())
         .and_then(|utf| utf.trim_end().parse::<DirenvVersion>())
-        .map_err(|()| ExitError {
-            exitcode: 1,
-            message: "Could not figure out the current `direnv` version (parse error)".to_string(),
-        })?;
+        .map_err(|()| ExitError::errmsg("Could not figure out the current `direnv` version (parse error)"))?;
     if version < MIN_DIRENV_VERSION {
         Err(ExitError::errmsg(format!(
             "`direnv` is version {}, but >= {} is required for lorri to function",
@@ -110,12 +107,9 @@ where
     F: FnOnce(Command) -> std::io::Result<T>,
 {
     let res = cmd(Command::new(executable));
-    res.map_err(|a| ExitError {
-        // TODO: other exit code for missing executable?
-        exitcode: 1,
-        message: match a.kind() {
-            std::io::ErrorKind::NotFound => format!("`{}`: executable not found", executable),
-            _ => format!("Could not start `{}`: {}", executable, a),
-        },
-    })
+    res.map_err(|a| ExitError::errmsg( // TODO: other exit code for missing executable?
+             match a.kind() {
+                std::io::ErrorKind::NotFound => format!("`{}`: executable not found", executable),
+                _ => format!("Could not start `{}`: {}", executable, a),
+            }))
 }

--- a/src/ops/init.rs
+++ b/src/ops/init.rs
@@ -1,6 +1,6 @@
 //! Bootstrap a new lorri project
 
-use crate::ops::{ok, ok_msg, ExitError, OpResult};
+use crate::ops::{ok_msg, OpResult};
 use std::fs::File;
 use std::io;
 use std::io::Write;
@@ -18,27 +18,20 @@ fn create_if_missing(path: &Path, contents: &str, msg: &str) -> Result<(), io::E
     }
 }
 
-fn to_op(e: Result<(), io::Error>) -> OpResult {
-    match e {
-        Ok(_) => ok(),
-        Err(e) => Err(ExitError::errmsg(format!("{}", e))),
-    }
-}
-
 /// See the documentation for lorri::cli::Command::Init for
 /// more details
 pub fn main(default_shell: &str, default_envrc: &str) -> OpResult {
-    to_op(create_if_missing(
+    create_if_missing(
         Path::new("./shell.nix"),
         default_shell,
         "shell.nix exists, skipping. Make sure it is of a form that works with nix-shell.",
-    ))?;
+    )?;
 
-    to_op(create_if_missing(
+    create_if_missing(
         Path::new("./.envrc"),
         default_envrc,
         ".envrc exists, skipping. Please add 'eval \"$(lorri direnv)\" to it to set up lorri support.",
-    ))?;
+    )?;
 
     ok_msg(String::from("\nSetup done."))
 }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -43,6 +43,17 @@ pub fn ok() -> OpResult {
     Ok(None)
 }
 
+/// Return an OpResult with a final message to print before exiting
+/// with a status code.
+/// Note, the final message is possibly intended to be consumed
+/// by automated tests.
+pub fn err<T>(exitcode: i32, message: T) -> OpResult
+where
+    T: Into<String>,
+{
+    Err(ExitError::err(exitcode, message))
+}
+
 impl ExitError {
     /// Exit 1 with an exit message
     pub fn errmsg<T>(message: T) -> ExitError
@@ -75,6 +86,13 @@ impl ExitError {
     /// Exit message to be displayed to the user on stderr
     pub fn message(&self) -> &str {
         &self.message
+    }
+}
+
+use std::io;
+impl From<io::Error> for ExitError {
+    fn from(e: io::Error) -> Self {
+        ExitError::errmsg(format!("{}", e))
     }
 }
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -24,8 +24,11 @@ pub struct ExitError {
     message: String,
 }
 
+/// Ops Result type; error corresponds with application exit
+pub type ExitResult<T> = Result<T, ExitError>;
+
 /// Final result from a CLI operation
-pub type OpResult = Result<Option<String>, ExitError>;
+pub type OpResult = ExitResult<Option<String>>;
 
 /// Return an OpResult with a final message to print before exit 0
 /// Note, the final message is possibly intended to be consumed
@@ -47,7 +50,7 @@ pub fn ok() -> OpResult {
 /// with a status code.
 /// Note, the final message is possibly intended to be consumed
 /// by automated tests.
-pub fn err<T>(exitcode: i32, message: T) -> OpResult
+pub fn err<S, T>(exitcode: i32, message: T) -> ExitResult<S>
 where
     T: Into<String>,
 {

--- a/src/ops/upgrade/mod.rs
+++ b/src/ops/upgrade/mod.rs
@@ -7,7 +7,7 @@
 use crate::changelog;
 use crate::cli;
 use crate::nix;
-use crate::ops::{ExitError, OpResult};
+use crate::ops::{err, ok_msg, OpResult};
 use crate::VERSION_BUILD_REV;
 use cas::ContentAddressable;
 use std::process::Command;
@@ -74,17 +74,15 @@ pub fn main(upgrade_target: cli::UpgradeTo, cas: &ContentAddressable) -> OpResul
             drop(gc_root);
 
             if status.success() {
-                Ok(Some(String::from("\nUpgrade successful.")))
+                ok_msg("\nUpgrade successful.")
             } else {
-                Err(ExitError::errmsg(String::from(
-                    "\nError: nix-env command was not successful!",
-                )))
+                err(1, "\nError: nix-env command was not successful!")
             }
         }
-        Err(e) => Err(ExitError::errmsg(format!(
+        Err(e) => err(1, format!(
             "Failed to build the update! Please report a bug!\n\
              {:?}",
             e
-        ))),
+        )),
     }
 }

--- a/src/ops/upgrade/mod.rs
+++ b/src/ops/upgrade/mod.rs
@@ -79,10 +79,13 @@ pub fn main(upgrade_target: cli::UpgradeTo, cas: &ContentAddressable) -> OpResul
                 err(1, "\nError: nix-env command was not successful!")
             }
         }
-        Err(e) => err(1, format!(
-            "Failed to build the update! Please report a bug!\n\
-             {:?}",
-            e
-        )),
+        Err(e) => err(
+            1,
+            format!(
+                "Failed to build the update! Please report a bug!\n\
+                 {:?}",
+                e
+            ),
+        ),
     }
 }

--- a/src/ops/watch.rs
+++ b/src/ops/watch.rs
@@ -2,7 +2,7 @@
 //! Can be used together with `direnv`.
 use crate::build_loop::{BuildError, BuildLoop};
 use crate::cli::WatchOptions;
-use crate::ops::{ok, ExitError, OpResult};
+use crate::ops::{ok, err, OpResult};
 use crate::project::Project;
 use std::fmt::Debug;
 use std::io::Write;
@@ -26,10 +26,8 @@ fn main_run_once(project: Project) -> OpResult {
             print_build_message(msg);
             ok()
         }
-        Err(BuildError::Unrecoverable(err)) => Err(ExitError::err(100, format!("{:?}", err))),
-        Err(BuildError::Recoverable(exit_failure)) => {
-            Err(ExitError::errmsg(format!("{:#?}", exit_failure)))
-        }
+        Err(BuildError::Unrecoverable(e)) => err(100, format!("{:?}", e)),
+        Err(BuildError::Recoverable(failure)) => err(1, format!("{:#?}", failure))
     }
 }
 

--- a/src/ops/watch.rs
+++ b/src/ops/watch.rs
@@ -2,7 +2,7 @@
 //! Can be used together with `direnv`.
 use crate::build_loop::{BuildError, BuildLoop};
 use crate::cli::WatchOptions;
-use crate::ops::{ok, err, OpResult};
+use crate::ops::{err, ok, OpResult};
 use crate::project::Project;
 use std::fmt::Debug;
 use std::io::Write;
@@ -27,7 +27,7 @@ fn main_run_once(project: Project) -> OpResult {
             ok()
         }
         Err(BuildError::Unrecoverable(e)) => err(100, format!("{:?}", e)),
-        Err(BuildError::Recoverable(failure)) => err(1, format!("{:#?}", failure))
+        Err(BuildError::Recoverable(failure)) => err(1, format!("{:#?}", failure)),
     }
 }
 


### PR DESCRIPTION
Some small changes with OpResult that result in slightly less ceremony around error handling in the ops module.

In part, this was an exercise in type manipulation in Rust, but I think the results are pleasing in a small way.