### PR TITLE
Pin nixpkgs to current NixOS 19.09 snapshot

### DIFF
--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/nixos/nixpkgs-channels.git",
-  "rev": "c7bcd4277cc9a656207b636dbc62fef21dc64c78",
-  "date": "2019-05-26T18:24:23+09:00",
-  "sha256": "1hg1rf57qprrh0gyhrhq95a236r34ahpp2q21s70g5xpax3qlvf3",
+  "rev": "80b42e630b23052d9525840a9742100a2ceaaa8f",
+  "date": "2019-10-20T20:13:02-04:00",
+  "sha256": "0243qiivxl3z51biy4f5y5cy81x5bki5dazl9wqwgnmd373gpmxy",
   "fetchSubmodules": false
 }

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/nixos/nixpkgs-channels.git",
-  "rev": "80b42e630b23052d9525840a9742100a2ceaaa8f",
-  "date": "2019-10-20T20:13:02-04:00",
-  "sha256": "0243qiivxl3z51biy4f5y5cy81x5bki5dazl9wqwgnmd373gpmxy",
+  "rev": "27a5ddcf747fb2bb81ea9c63f63f2eb3eec7a2ec",
+  "date": "2019-10-23T23:56:43+02:00",
+  "sha256": "1bp11q2marsqj3g2prdrghkhmv483ab5pi078d83xkhkk2jh3h81",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
The current pinned snapshot is five months old. Updating it means fewer things need to be downloaded initially.