### PR TITLE
lib/NixFile make absolute by construction

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -460,7 +460,7 @@ derivation {{
     #[test]
     fn non_utf8_nix_output() -> std::io::Result<()> {
         let tmp = tempfile::tempdir()?;
-        let cas = ContentAddressable::new(crate::AbsPathBuf::new_unchecked(tmp.path().to_owned()))?;
+        let cas = ContentAddressable::new(crate::AbsPathBuf::new(tmp.path().to_owned()).unwrap())?;
 
         let inner_drv = drv(
             "dep",
@@ -523,7 +523,7 @@ in {}
     #[test]
     fn gracefully_handle_failing_build() -> std::io::Result<()> {
         let tmp = tempfile::tempdir()?;
-        let cas = ContentAddressable::new(crate::AbsPathBuf::new_unchecked(tmp.path().to_owned()))?;
+        let cas = ContentAddressable::new(crate::AbsPathBuf::new(tmp.path().to_owned()).unwrap())?;
 
         let d = crate::NixFile::from(cas.file_from_string(&drv(
             "shell",
@@ -581,12 +581,12 @@ dir-as-source = ./dir;
         std::fs::write(&foo_baz, "\"This file should be watched\"")?;
 
         let cas =
-            ContentAddressable::new(crate::AbsPathBuf::new_unchecked(cas_tmp.path().join("cas")))?;
+            ContentAddressable::new(crate::AbsPathBuf::new(cas_tmp.path().join("cas")).unwrap())?;
 
         let (tx, rx) = chan::unbounded();
         let inst_info = instrumented_instantiation(
             tx,
-            &NixFile::from(crate::AbsPathBuf::new_unchecked(shell)),
+            &NixFile::from(crate::AbsPathBuf::new(shell).unwrap()),
             &cas,
         )
         .unwrap();

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -25,6 +25,8 @@ impl ContentAddressable {
     /// pointing to another `ContentAddressable` store.
     /// If it is a directory with some other data,
     /// the correctness cannot be guaranteed.
+    ///
+    /// TODO: assert that it’s an absolute path
     pub fn new(store_dir: PathBuf) -> std::io::Result<ContentAddressable> {
         std::fs::create_dir_all(&store_dir)?;
         Ok(ContentAddressable { store_dir })

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -86,7 +86,7 @@ mod tests {
     use AbsPathBuf;
 
     fn abs_path(td: &tempfile::TempDir) -> AbsPathBuf {
-        AbsPathBuf::new_unchecked(td.path().to_owned())
+        AbsPathBuf::new(td.path().to_owned()).unwrap()
     }
 
     /// Tests adding some content to the store and whether

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,11 +4,14 @@ extern crate directories;
 
 use self::directories::ProjectDirs;
 use crate::cas::ContentAddressable;
+use crate::AbsPathBuf;
 use std::path::{Path, PathBuf};
 
 /// Path constants like the GC root directory.
 pub struct Paths {
+    // TODO: make AbsPathBuf
     gc_root_dir: PathBuf,
+    // TODO: make AbsPathBuf
     daemon_socket_file: PathBuf,
     cas_store: ContentAddressable,
 }
@@ -32,7 +35,7 @@ pub enum PathsInitError {
     /// The CAS creation failed.
     #[allow(missing_docs)]
     CasCantBeCreated {
-        cas_dir: PathBuf,
+        cas_dir: AbsPathBuf,
         err: std::io::Error,
     },
 }
@@ -51,7 +54,15 @@ impl Paths {
             // fall back to the cache dir on non-linux
             .unwrap_or_else(|| pd.cache_dir())
             .to_owned();
-        let cas_dir = pd.cache_dir().join("cas");
+
+        // TODO: return as good error value
+        assert!(
+            pd.cache_dir().is_absolute(),
+            "Your cache directory is not an absolute path! It is: {}",
+            pd.cache_dir().display()
+        );
+        let abs_cache_dir = AbsPathBuf::new_unchecked(pd.cache_dir().to_owned());
+        let cas_dir = abs_cache_dir.join("cas");
         Ok(Paths {
             gc_root_dir: create_dir(gc_root_dir.clone()).map_err(|err| {
                 PathsInitError::GcRootsDirectoryCantBeCreated { gc_root_dir, err }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,14 +5,11 @@ extern crate directories;
 use self::directories::ProjectDirs;
 use crate::cas::ContentAddressable;
 use crate::AbsPathBuf;
-use std::path::{Path, PathBuf};
 
 /// Path constants like the GC root directory.
 pub struct Paths {
-    // TODO: make AbsPathBuf
-    gc_root_dir: PathBuf,
-    // TODO: make AbsPathBuf
-    daemon_socket_file: PathBuf,
+    gc_root_dir: AbsPathBuf,
+    daemon_socket_file: AbsPathBuf,
     cas_store: ContentAddressable,
 }
 
@@ -23,13 +20,13 @@ pub enum PathsInitError {
     /// The `gc_root_dir` creation failed.
     #[allow(missing_docs)]
     GcRootsDirectoryCantBeCreated {
-        gc_root_dir: PathBuf,
+        gc_root_dir: AbsPathBuf,
         err: std::io::Error,
     },
     /// The `socket_dir` creation failed.
     #[allow(missing_docs)]
     SocketDirCantBeCreated {
-        socket_dir: PathBuf,
+        socket_dir: AbsPathBuf,
         err: std::io::Error,
     },
     /// The CAS creation failed.
@@ -45,15 +42,9 @@ impl Paths {
     pub fn initialize() -> Result<Paths, PathsInitError> {
         let pd = ProjectDirs::from("com.github.target.lorri", "lorri", "lorri")
             .expect("Could not determine lorri project/cache directories, please set $HOME");
-        let create_dir = |dir: PathBuf| -> std::io::Result<PathBuf> {
+        let create_dir = |dir: AbsPathBuf| -> std::io::Result<AbsPathBuf> {
             std::fs::create_dir_all(&dir).and(Ok(dir))
         };
-        let gc_root_dir = pd.cache_dir().join("gc_roots");
-        let runtime_dir = pd
-            .runtime_dir()
-            // fall back to the cache dir on non-linux
-            .unwrap_or_else(|| pd.cache_dir())
-            .to_owned();
 
         // TODO: return as good error value
         assert!(
@@ -62,25 +53,39 @@ impl Paths {
             pd.cache_dir().display()
         );
         let abs_cache_dir = AbsPathBuf::new_unchecked(pd.cache_dir().to_owned());
+        let gc_root_dir = abs_cache_dir.join("gc_roots");
         let cas_dir = abs_cache_dir.join("cas");
+        let runtime_dir = pd
+            .runtime_dir()
+            // fall back to the cache dir on non-linux
+            .unwrap_or_else(|| pd.cache_dir())
+            .to_owned();
+        // TODO: return as good error value
+        assert!(
+            runtime_dir.is_absolute(),
+            "Your runtime directory is not an absolute path! It is: {}",
+            runtime_dir.display()
+        );
+        let abs_runtime_dir = AbsPathBuf::new_unchecked(runtime_dir);
+
         Ok(Paths {
-            gc_root_dir: create_dir(gc_root_dir.clone()).map_err(|err| {
+            gc_root_dir: create_dir(abs_cache_dir.join("gc_roots")).map_err(|err| {
                 PathsInitError::GcRootsDirectoryCantBeCreated { gc_root_dir, err }
             })?,
-            daemon_socket_file: create_dir(runtime_dir.clone())
+            daemon_socket_file: create_dir(abs_runtime_dir.clone())
                 .map_err(|err| PathsInitError::SocketDirCantBeCreated {
-                    socket_dir: runtime_dir,
+                    socket_dir: abs_runtime_dir,
                     err,
                 })?
                 .join("daemon.socket"),
-            cas_store: ContentAddressable::new(cas_dir.clone())
+            cas_store: ContentAddressable::new(abs_cache_dir.join("cas"))
                 .map_err(|err| PathsInitError::CasCantBeCreated { cas_dir, err })?,
         })
     }
 
     /// Default location in the user's XDG directories to keep
     /// GC root pins
-    pub fn gc_root_dir(&self) -> &Path {
+    pub fn gc_root_dir(&self) -> &AbsPathBuf {
         &self.gc_root_dir
     }
 
@@ -88,7 +93,7 @@ impl Paths {
     ///
     /// The daemon uses this path to create its Unix socket on
     /// (see `::daemon` and `::socket::communicate`).
-    pub fn daemon_socket_file(&self) -> &Path {
+    pub fn daemon_socket_file(&self) -> &AbsPathBuf {
         &self.daemon_socket_file
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,13 +52,22 @@ use std::path::{Path, PathBuf};
 include!(concat!(env!("OUT_DIR"), "/build_rev.rs"));
 
 /// A .nix file.
+///
+/// Is guaranteed to have an absolute path by construction.
 #[derive(Hash, PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
 pub struct NixFile(PathBuf);
 
 impl NixFile {
-    /// Underlying `&OsStr`.
-    pub fn as_os_str(&self) -> &std::ffi::OsStr {
-        self.0.as_os_str()
+    /// Convert from a known absolute path.
+    ///
+    /// Passing a relative path is a programming bug (unchecked).
+    pub fn from_absolute_path_unchecked(path: PathBuf) -> Self {
+        NixFile(path)
+    }
+
+    /// Absolute path of this file
+    pub fn as_absolute_path(&self) -> &Path {
+        &self.0
     }
 }
 
@@ -66,18 +75,6 @@ impl NixFile {
 impl std::fmt::Display for NixFile {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         self.0.display().fmt(f)
-    }
-}
-
-impl From<&std::ffi::OsStr> for NixFile {
-    fn from(s: &std::ffi::OsStr) -> NixFile {
-        NixFile(PathBuf::from(s.to_owned()))
-    }
-}
-
-impl From<PathBuf> for NixFile {
-    fn from(p: PathBuf) -> NixFile {
-        NixFile(p)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,18 @@ pub struct NixFile(AbsPathBuf);
 pub struct AbsPathBuf(PathBuf);
 
 impl AbsPathBuf {
+    /// Convert from a path to an absolute path.
+    ///
+    /// If the path is not absolute, the original `PathBuf`
+    /// is returned (similar to `OsString.into_string()`)
+    pub fn new(path: PathBuf) -> Result<Self, PathBuf> {
+        if path.is_absolute() {
+            Ok(Self::new_unchecked(path))
+        } else {
+            Err(path)
+        }
+    }
+
     /// Convert from a known absolute path.
     ///
     /// Passing a relative path is a programming bug (unchecked).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,20 @@ impl AbsPathBuf {
     pub fn display(&self) -> std::path::Display {
         self.0.display()
     }
+
+    /// Joins a path to the end of this absolute path.
+    /// If the path is absolute, it will replace this absolute path.
+    pub fn join<P: AsRef<Path>>(&self, pb: P) -> Self {
+        let mut new = self.0.to_owned();
+        new.push(pb);
+        Self::new_unchecked(new)
+    }
+}
+
+impl AsRef<Path> for AbsPathBuf {
+    fn as_ref(&self) -> &Path {
+        self.as_absolute_path()
+    }
 }
 
 impl NixFile {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,23 +55,45 @@ include!(concat!(env!("OUT_DIR"), "/build_rev.rs"));
 ///
 /// Is guaranteed to have an absolute path by construction.
 #[derive(Hash, PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
-pub struct NixFile(PathBuf);
+pub struct NixFile(AbsPathBuf);
 
-impl NixFile {
+/// Path guaranteed to be absolute by construction.
+#[derive(Hash, PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+pub struct AbsPathBuf(PathBuf);
+
+impl AbsPathBuf {
     /// Convert from a known absolute path.
     ///
     /// Passing a relative path is a programming bug (unchecked).
-    pub fn from_absolute_path_unchecked(path: PathBuf) -> Self {
-        NixFile(path)
+    pub fn new_unchecked(path: PathBuf) -> Self {
+        AbsPathBuf(path)
     }
 
-    /// Absolute path of this file
+    /// The absolute path, as `&Path`.
     pub fn as_absolute_path(&self) -> &Path {
         &self.0
     }
+
+    /// Proxy through the `Display` class for `PathBuf`.
+    pub fn display(&self) -> std::path::Display {
+        self.0.display()
+    }
 }
 
-/// Proxy through the `Display` class for `PathBuf`.
+impl NixFile {
+    /// Absolute path of this file.
+    pub fn as_absolute_path(&self) -> &Path {
+        &self.0.as_absolute_path()
+    }
+}
+
+impl From<AbsPathBuf> for NixFile {
+    fn from(abs_path: AbsPathBuf) -> Self {
+        NixFile(abs_path)
+    }
+}
+
+/// Proxy through the `Display` class for `AbsPathBuf`.
 impl std::fmt::Display for NixFile {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         self.0.display().fmt(f)

--- a/src/locate_file.rs
+++ b/src/locate_file.rs
@@ -21,7 +21,8 @@ impl From<std::io::Error> for FileLocationError {
     }
 }
 
-/// Hunt for filename `name` in the current directory
+/// Hunt for filename `name` in the current directory.
+/// If `path` is absolute, it returns `path`.
 pub fn in_cwd(name: &PathBuf) -> Result<PathBuf, FileLocationError> {
     let mut path = env::current_dir()?;
     path.push(name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,13 @@ fn find_nix_file(shellfile: &PathBuf) -> Result<NixFile, ExitError> {
 }
 
 fn create_project(paths: &constants::Paths, shell_nix: NixFile) -> Result<Project, ExitError> {
-    Project::new(shell_nix, &paths.gc_root_dir(), paths.cas_store().clone()).or_else(|e| {
+    Project::new(
+        shell_nix,
+        // TODO: pass the AbsPathDir
+        &paths.gc_root_dir().as_absolute_path(),
+        paths.cas_store().clone(),
+    )
+    .or_else(|e| {
         Err(ExitError::temporary(format!(
             "Could not set up project paths: {:#?}",
             e

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ extern crate human_panic;
 
 use lorri::constants;
 use lorri::locate_file;
-use lorri::{AbsPathBuf, NixFile};
+use lorri::NixFile;
 
 use lorri::cli::{Arguments, Command};
 use lorri::ops::error::{ExitError, OpResult};
@@ -51,9 +51,8 @@ fn main() {
 /// that instructs the user how to write a minimal `shell.nix`.
 fn find_nix_file(shellfile: &PathBuf) -> Result<NixFile, ExitError> {
     // use shell.nix from cwd
-    Ok(NixFile::from(
-        // `::in_cwd` is guaranteed to return an absolute path
-        AbsPathBuf::new_unchecked(locate_file::in_cwd(&shellfile).map_err(|_| {
+    Ok(NixFile::from(locate_file::in_cwd(&shellfile).map_err(
+        |_| {
             ExitError::user_error(format!(
                 "`{}` does not exist\n\
                  You can use the following minimal `shell.nix` to get started:\n\n\
@@ -61,8 +60,8 @@ fn find_nix_file(shellfile: &PathBuf) -> Result<NixFile, ExitError> {
                 shellfile.display(),
                 TRIVIAL_SHELL_SRC
             ))
-        })?),
-    ))
+        },
+    )?))
 }
 
 fn create_project(paths: &constants::Paths, shell_nix: NixFile) -> Result<Project, ExitError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ extern crate human_panic;
 
 use lorri::constants;
 use lorri::locate_file;
-use lorri::NixFile;
+use lorri::{AbsPathBuf, NixFile};
 
 use lorri::cli::{Arguments, Command};
 use lorri::ops::error::{ExitError, OpResult};
@@ -51,8 +51,9 @@ fn main() {
 /// that instructs the user how to write a minimal `shell.nix`.
 fn find_nix_file(shellfile: &PathBuf) -> Result<NixFile, ExitError> {
     // use shell.nix from cwd
-    Ok(NixFile::from_absolute_path_unchecked(
-        locate_file::in_cwd(&shellfile).map_err(|_| {
+    Ok(NixFile::from(
+        // `::in_cwd` is guaranteed to return an absolute path
+        AbsPathBuf::new_unchecked(locate_file::in_cwd(&shellfile).map_err(|_| {
             ExitError::user_error(format!(
                 "`{}` does not exist\n\
                  You can use the following minimal `shell.nix` to get started:\n\n\
@@ -60,7 +61,7 @@ fn find_nix_file(shellfile: &PathBuf) -> Result<NixFile, ExitError> {
                 shellfile.display(),
                 TRIVIAL_SHELL_SRC
             ))
-        })?,
+        })?),
     ))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,8 +49,8 @@ fn main() {
 /// Try to read `shell.nix` from the current working dir.
 fn get_shell_nix(shellfile: &PathBuf) -> Result<NixFile, ExitError> {
     // use shell.nix from cwd
-    Ok(NixFile::from(locate_file::in_cwd(&shellfile).map_err(
-        |_| {
+    Ok(NixFile::from_absolute_path_unchecked(
+        locate_file::in_cwd(&shellfile).map_err(|_| {
             ExitError::user_error(format!(
                 "`{}` does not exist\n\
                  You can use the following minimal `shell.nix` to get started:\n\n\
@@ -58,8 +58,8 @@ fn get_shell_nix(shellfile: &PathBuf) -> Result<NixFile, ExitError> {
                 shellfile.display(),
                 TRIVIAL_SHELL_SRC
             ))
-        },
-    )?))
+        })?,
+    ))
 }
 
 fn create_project(paths: &constants::Paths, shell_nix: NixFile) -> Result<Project, ExitError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn find_nix_file(shellfile: &PathBuf) -> Result<NixFile, ExitError> {
 fn create_project(paths: &constants::Paths, shell_nix: NixFile) -> Result<Project, ExitError> {
     Project::new(
         shell_nix,
-        // TODO: pass the AbsPathDir
+        // TODO: pass the AbsPathBuf
         &paths.gc_root_dir().as_absolute_path(),
         paths.cas_store().clone(),
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,8 +46,10 @@ fn main() {
     exit(result);
 }
 
-/// Try to read `shell.nix` from the current working dir.
-fn get_shell_nix(shellfile: &PathBuf) -> Result<NixFile, ExitError> {
+/// Reads a nix filename given by the user and either returns
+/// the `NixFile` type or exists with a helpful error message
+/// that instructs the user how to write a minimal `shell.nix`.
+fn find_nix_file(shellfile: &PathBuf) -> Result<NixFile, ExitError> {
     // use shell.nix from cwd
     Ok(NixFile::from_absolute_path_unchecked(
         locate_file::in_cwd(&shellfile).map_err(|_| {
@@ -76,14 +78,14 @@ fn run_command(opts: Arguments) -> OpResult {
     let paths = lorri::ops::get_paths()?;
     match opts.command {
         Command::Info(opts) => {
-            get_shell_nix(&opts.nix_file).and_then(|sn| info::main(create_project(&paths, sn)?))
+            find_nix_file(&opts.nix_file).and_then(|sn| info::main(create_project(&paths, sn)?))
         }
 
         Command::Direnv(opts) => {
-            get_shell_nix(&opts.nix_file).and_then(|sn| direnv::main(create_project(&paths, sn)?))
+            find_nix_file(&opts.nix_file).and_then(|sn| direnv::main(create_project(&paths, sn)?))
         }
 
-        Command::Watch(opts) => get_shell_nix(&opts.nix_file)
+        Command::Watch(opts) => find_nix_file(&opts.nix_file)
             .and_then(|sn| watch::main(create_project(&paths, sn)?, opts)),
 
         Command::Daemon => daemon::main(),
@@ -91,7 +93,7 @@ fn run_command(opts: Arguments) -> OpResult {
         Command::Upgrade(opts) => upgrade::main(opts, paths.cas_store()),
 
         // TODO: remove
-        Command::Ping_(opts) => get_shell_nix(&opts.nix_file).and_then(ping::main),
+        Command::Ping_(opts) => find_nix_file(&opts.nix_file).and_then(ping::main),
 
         Command::Init => init::main(TRIVIAL_SHELL_SRC, DEFAULT_ENVRC),
     }

--- a/src/ops/daemon.rs
+++ b/src/ops/daemon.rs
@@ -64,7 +64,8 @@ pub fn main() -> OpResult {
         for start_build in accept_messages_rx {
             let project = crate::project::Project::new(
                 start_build.nix_file,
-                paths.gc_root_dir(),
+                // TODO: pass the AbsPathDir
+                paths.gc_root_dir().as_absolute_path(),
                 paths.cas_store().clone(),
             )
             // TODO: the project needs to create its gc root dir

--- a/src/ops/direnv/mod.rs
+++ b/src/ops/direnv/mod.rs
@@ -75,7 +75,9 @@ watch_file "$EVALUATION_ROOT"
 "#,
         root_paths.shell_gc_root,
         socket_path
-            .into_os_string()
+            .as_absolute_path()
+            .as_os_str()
+            .to_owned()
             .into_string()
             .expect("Socket path is not UTF-8 clean!"),
         include_str!("envrc.bash")

--- a/src/ops/upgrade/mod.rs
+++ b/src/ops/upgrade/mod.rs
@@ -41,7 +41,7 @@ pub fn main(upgrade_target: cli::UpgradeTo, cas: &ContentAddressable) -> OpResul
     let expr = {
         let src = String::from(upgrade_target);
         println!("Upgrading from source: {}", src);
-        let mut expr = nix::CallOpts::file(&upgrade_expr);
+        let mut expr = nix::CallOpts::file(&upgrade_expr.as_absolute_path());
         expr.argstr("src", &src);
         // ugly hack to prevent expr from being mutable outside,
         // since I can't sort out how to chain argstr and still

--- a/src/project.rs
+++ b/src/project.rs
@@ -34,7 +34,10 @@ impl Project {
         gc_root_dir: &Path,
         cas: ContentAddressable,
     ) -> std::io::Result<Project> {
-        let hash = format!("{:x}", md5::compute(nix_file.as_os_str().as_bytes()));
+        let hash = format!(
+            "{:x}",
+            md5::compute(nix_file.as_absolute_path().as_os_str().as_bytes())
+        );
         let project_gc_root = gc_root_dir.join(&hash).join("gc_root").to_path_buf();
 
         std::fs::create_dir_all(&project_gc_root)?;

--- a/src/project.rs
+++ b/src/project.rs
@@ -14,6 +14,7 @@ pub struct Project {
     /// Absolute path to this project’s nix file.
     pub nix_file: NixFile,
 
+    // TODO: make into AbsPathBuf
     /// Directory in which this project’s
     /// garbage collection roots are stored.
     gc_root_path: PathBuf,

--- a/src/socket/path.rs
+++ b/src/socket/path.rs
@@ -57,7 +57,7 @@ impl<'a> SocketPath<'a> {
             .unwrap_or_else(|| panic!("Socket file ({:?}) must have a parent directory", self.0))
             .to_owned();
         new_file.push(name);
-        // We didn’t do anything to not make the path relative
+        // We didn’t do anything to make the path relative
         AbsPathBuf::new_unchecked(new_file)
     }
 

--- a/tests/daemon/main.rs
+++ b/tests/daemon/main.rs
@@ -66,7 +66,9 @@ pub fn start_job_with_ping() -> std::io::Result<()> {
         .recv_timeout(Duration::from_millis(100))
         .unwrap();
 
-    let cas = ContentAddressable::new(tempdir.path().join("cas")).unwrap();
+    let cas =
+        ContentAddressable::new(AbsPathBuf::new_unchecked(tempdir.path().to_owned()).join("cas"))
+            .unwrap();
     let project = Project::new(start_build.nix_file, &tempdir.path().join("gc_root"), cas).unwrap();
     daemon.add(project);
 

--- a/tests/daemon/main.rs
+++ b/tests/daemon/main.rs
@@ -32,8 +32,8 @@ pub fn start_job_with_ping() -> std::io::Result<()> {
     let tempdir = tempfile::tempdir()?;
 
     // create unix socket file
-    let p = &tempdir.path().join("socket");
-    let socket_path = SocketPath::from(p);
+    let p = AbsPathBuf::new_unchecked(tempdir.path().to_owned()).join("socket");
+    let socket_path = SocketPath::from(&p);
     let listener = listener::Listener::new(&socket_path).unwrap();
 
     // The daemon knows how to build stuff
@@ -94,8 +94,8 @@ pub fn start_two_listeners_on_same_socket() -> std::io::Result<()> {
     let tempdir = tempfile::tempdir()?;
 
     // create unix socket file
-    let p = &tempdir.path().join("socket");
-    let socket_path = SocketPath::from(p);
+    let p = AbsPathBuf::new_unchecked(tempdir.path().to_owned()).join("socket");
+    let socket_path = SocketPath::from(&p);
     let listener = listener::Listener::new(&socket_path).unwrap();
 
     match listener::Listener::new(&socket_path) {

--- a/tests/daemon/main.rs
+++ b/tests/daemon/main.rs
@@ -56,7 +56,7 @@ pub fn start_job_with_ping() -> std::io::Result<()> {
         .connect(&socket_path)
         .unwrap()
         .write(&Ping {
-            nix_file: NixFile::from(PathBuf::from("/who/cares")),
+            nix_file: NixFile::from_absolute_path_unchecked(PathBuf::from("/who/cares")),
         })
         .unwrap();
 

--- a/tests/daemon/main.rs
+++ b/tests/daemon/main.rs
@@ -9,7 +9,7 @@ use lorri::socket::communicate::{client, listener};
 use lorri::socket::communicate::{CommunicationType, Ping};
 use lorri::socket::path::SocketPath;
 use lorri::socket::{ReadWriter, Timeout};
-use lorri::NixFile;
+use lorri::{AbsPathBuf, NixFile};
 use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
 use std::thread;
@@ -56,7 +56,7 @@ pub fn start_job_with_ping() -> std::io::Result<()> {
         .connect(&socket_path)
         .unwrap()
         .write(&Ping {
-            nix_file: NixFile::from_absolute_path_unchecked(PathBuf::from("/who/cares")),
+            nix_file: NixFile::from(AbsPathBuf::new_unchecked(PathBuf::from("/who/cares"))),
         })
         .unwrap();
 

--- a/tests/daemon/main.rs
+++ b/tests/daemon/main.rs
@@ -32,7 +32,9 @@ pub fn start_job_with_ping() -> std::io::Result<()> {
     let tempdir = tempfile::tempdir()?;
 
     // create unix socket file
-    let p = AbsPathBuf::new_unchecked(tempdir.path().to_owned()).join("socket");
+    let p = AbsPathBuf::new(tempdir.path().to_owned())
+        .unwrap()
+        .join("socket");
     let socket_path = SocketPath::from(&p);
     let listener = listener::Listener::new(&socket_path).unwrap();
 
@@ -56,7 +58,7 @@ pub fn start_job_with_ping() -> std::io::Result<()> {
         .connect(&socket_path)
         .unwrap()
         .write(&Ping {
-            nix_file: NixFile::from(AbsPathBuf::new_unchecked(PathBuf::from("/who/cares"))),
+            nix_file: NixFile::from(AbsPathBuf::new(PathBuf::from("/who/cares")).unwrap()),
         })
         .unwrap();
 
@@ -66,9 +68,12 @@ pub fn start_job_with_ping() -> std::io::Result<()> {
         .recv_timeout(Duration::from_millis(100))
         .unwrap();
 
-    let cas =
-        ContentAddressable::new(AbsPathBuf::new_unchecked(tempdir.path().to_owned()).join("cas"))
-            .unwrap();
+    let cas = ContentAddressable::new(
+        AbsPathBuf::new(tempdir.path().to_owned())
+            .unwrap()
+            .join("cas"),
+    )
+    .unwrap();
     let project = Project::new(start_build.nix_file, &tempdir.path().join("gc_root"), cas).unwrap();
     daemon.add(project);
 
@@ -94,7 +99,9 @@ pub fn start_two_listeners_on_same_socket() -> std::io::Result<()> {
     let tempdir = tempfile::tempdir()?;
 
     // create unix socket file
-    let p = AbsPathBuf::new_unchecked(tempdir.path().to_owned()).join("socket");
+    let p = AbsPathBuf::new(tempdir.path().to_owned())
+        .unwrap()
+        .join("socket");
     let socket_path = SocketPath::from(&p);
     let listener = listener::Listener::new(&socket_path).unwrap();
 

--- a/tests/integration/direnvtestcase.rs
+++ b/tests/integration/direnvtestcase.rs
@@ -7,7 +7,7 @@ use lorri::{
     cas::ContentAddressable,
     ops::direnv,
     project::Project,
-    NixFile,
+    AbsPathBuf, NixFile,
 };
 use std::fs::File;
 use std::io::Write;
@@ -32,7 +32,7 @@ impl DirenvTestCase {
         let test_root =
             PathBuf::from_iter(&[env!("CARGO_MANIFEST_DIR"), "tests", "integration", name]);
 
-        let shell_file = NixFile::from_absolute_path_unchecked(test_root.join("shell.nix"));
+        let shell_file = NixFile::from(AbsPathBuf::new_unchecked(test_root.join("shell.nix")));
 
         let cas = ContentAddressable::new(cachedir.path().join("cas").to_owned()).unwrap();
         let project = Project::new(

--- a/tests/integration/direnvtestcase.rs
+++ b/tests/integration/direnvtestcase.rs
@@ -32,7 +32,7 @@ impl DirenvTestCase {
         let test_root =
             PathBuf::from_iter(&[env!("CARGO_MANIFEST_DIR"), "tests", "integration", name]);
 
-        let shell_file = NixFile::from(test_root.join("shell.nix"));
+        let shell_file = NixFile::from_absolute_path_unchecked(test_root.join("shell.nix"));
 
         let cas = ContentAddressable::new(cachedir.path().join("cas").to_owned()).unwrap();
         let project = Project::new(

--- a/tests/integration/direnvtestcase.rs
+++ b/tests/integration/direnvtestcase.rs
@@ -34,7 +34,12 @@ impl DirenvTestCase {
 
         let shell_file = NixFile::from(AbsPathBuf::new_unchecked(test_root.join("shell.nix")));
 
-        let cas = ContentAddressable::new(cachedir.path().join("cas").to_owned()).unwrap();
+        let cas = ContentAddressable::new(
+            AbsPathBuf::new_unchecked(cachedir.path().to_owned())
+                .join("cas")
+                .to_owned(),
+        )
+        .unwrap();
         let project = Project::new(
             shell_file.clone(),
             &cachedir.path().join("gc_roots").to_owned(),

--- a/tests/integration/direnvtestcase.rs
+++ b/tests/integration/direnvtestcase.rs
@@ -32,10 +32,11 @@ impl DirenvTestCase {
         let test_root =
             PathBuf::from_iter(&[env!("CARGO_MANIFEST_DIR"), "tests", "integration", name]);
 
-        let shell_file = NixFile::from(AbsPathBuf::new_unchecked(test_root.join("shell.nix")));
+        let shell_file = NixFile::from(AbsPathBuf::new(test_root.join("shell.nix")).unwrap());
 
         let cas = ContentAddressable::new(
-            AbsPathBuf::new_unchecked(cachedir.path().to_owned())
+            AbsPathBuf::new(cachedir.path().to_owned())
+                .unwrap()
                 .join("cas")
                 .to_owned(),
         )


### PR DESCRIPTION
This expands on https://github.com/target/lorri/pull/194 a bit by making `NixFile` always be an absolute path, correct by construction.

It then factors out the absolute path part to also add it to `cas.rs` and `constants/Paths`.
We should propagate further into `project.rs` and `roots.rs`, but I’ve left that as a TODO for now.

Most of these changes are rather mechanical (and mostly trivial).

cc @curiousleo 