### PR TITLE
Exit error consolidation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,8 @@ use lorri::locate_file;
 use lorri::NixFile;
 
 use lorri::cli::{Arguments, Command};
-use lorri::ops::{daemon, direnv, info, init, ping, upgrade, watch, ExitError, OpResult};
+use lorri::ops::error::{ExitError, OpResult};
+use lorri::ops::{daemon, direnv, info, init, ping, upgrade, watch};
 use lorri::project::Project;
 use std::path::PathBuf;
 use structopt::StructOpt;

--- a/src/ops/daemon.rs
+++ b/src/ops/daemon.rs
@@ -17,7 +17,7 @@ pub fn main() -> OpResult {
     let socket_path = crate::socket::path::SocketPath::from(&daemon_socket_file);
     // TODO: move listener into Daemon struct?
     let listener = listener::Listener::new(&socket_path).map_err(|e| match e {
-        crate::socket::path::BindError::OtherProcessListening => ExitError::errmsg(format!(
+        crate::socket::path::BindError::OtherProcessListening => ExitError::user_error(format!(
             "Another daemon is already listening on the socket at {}. \
              We are currently only allowing one daemon to be running at the same time.",
             socket_path.display()

--- a/src/ops/daemon.rs
+++ b/src/ops/daemon.rs
@@ -2,7 +2,7 @@
 //! Can be used together with `direnv`.
 
 use crate::daemon::Daemon;
-use crate::ops::{ok, ExitError, OpResult};
+use crate::ops::error::{ok, ExitError, OpResult};
 use crate::socket::communicate::listener;
 use crate::socket::communicate::CommunicationType;
 use crate::socket::ReadWriter;

--- a/src/ops/direnv/mod.rs
+++ b/src/ops/direnv/mod.rs
@@ -88,9 +88,10 @@ fn check_direnv_version() -> OpResult {
     let version = std::str::from_utf8(&out.stdout)
         .map_err(|_| ())
         .and_then(|utf| utf.trim_end().parse::<DirenvVersion>())
-        .map_err(|()| ExitError {
-            exitcode: 1,
-            message: "Could not figure out the current `direnv` version (parse error)".to_string(),
+        .map_err(|()| {
+            ExitError::errmsg(
+                "Could not figure out the current `direnv` version (parse error)".to_string(),
+            )
         })?;
     if version < MIN_DIRENV_VERSION {
         Err(ExitError::errmsg(format!(
@@ -110,12 +111,11 @@ where
     F: FnOnce(Command) -> std::io::Result<T>,
 {
     let res = cmd(Command::new(executable));
-    res.map_err(|a| ExitError {
-        // TODO: other exit code for missing executable?
-        exitcode: 1,
-        message: match a.kind() {
+    res.map_err(|a| {
+        // TODO use a different exit-code for the missing executable
+        ExitError::errmsg(match a.kind() {
             std::io::ErrorKind::NotFound => format!("`{}`: executable not found", executable),
             _ => format!("Could not start `{}`: {}", executable, a),
-        },
+        })
     })
 }

--- a/src/ops/direnv/mod.rs
+++ b/src/ops/direnv/mod.rs
@@ -3,7 +3,7 @@
 mod version;
 
 use self::version::{DirenvVersion, MIN_DIRENV_VERSION};
-use crate::ops::{ok, ok_msg, ExitError, OpResult};
+use crate::ops::error::{ok, ok_msg, ExitError, OpResult};
 use crate::project::roots::Roots;
 use crate::project::Project;
 use crate::socket::communicate::client;

--- a/src/ops/direnv/mod.rs
+++ b/src/ops/direnv/mod.rs
@@ -89,12 +89,12 @@ fn check_direnv_version() -> OpResult {
         .map_err(|_| ())
         .and_then(|utf| utf.trim_end().parse::<DirenvVersion>())
         .map_err(|()| {
-            ExitError::errmsg(
+            ExitError::environment_problem(
                 "Could not figure out the current `direnv` version (parse error)".to_string(),
             )
         })?;
     if version < MIN_DIRENV_VERSION {
-        Err(ExitError::errmsg(format!(
+        Err(ExitError::environment_problem(format!(
             "`direnv` is version {}, but >= {} is required for lorri to function",
             version, MIN_DIRENV_VERSION
         )))

--- a/src/ops/direnv/mod.rs
+++ b/src/ops/direnv/mod.rs
@@ -112,8 +112,7 @@ where
 {
     let res = cmd(Command::new(executable));
     res.map_err(|a| {
-        // TODO use a different exit-code for the missing executable
-        ExitError::errmsg(match a.kind() {
+        ExitError::missing_executable(match a.kind() {
             std::io::ErrorKind::NotFound => format!("`{}`: executable not found", executable),
             _ => format!("Could not start `{}`: {}", executable, a),
         })

--- a/src/ops/info.rs
+++ b/src/ops/info.rs
@@ -1,6 +1,6 @@
 //! The info callable is for printing
 
-use crate::ops::{ok, OpResult};
+use crate::ops::error::{ok, OpResult};
 use crate::project;
 use crate::VERSION_BUILD_REV;
 

--- a/src/ops/init.rs
+++ b/src/ops/init.rs
@@ -1,6 +1,6 @@
 //! Bootstrap a new lorri project
 
-use crate::ops::{ok_msg, ExitError, OpResult};
+use crate::ops::error::{ok_msg, ExitError, OpResult};
 use std::fs::File;
 use std::io;
 use std::io::Write;

--- a/src/ops/init.rs
+++ b/src/ops/init.rs
@@ -1,6 +1,6 @@
 //! Bootstrap a new lorri project
 
-use crate::ops::{ok, ok_msg, ExitError, OpResult};
+use crate::ops::{ok_msg, ExitError, OpResult};
 use std::fs::File;
 use std::io;
 use std::io::Write;
@@ -18,27 +18,21 @@ fn create_if_missing(path: &Path, contents: &str, msg: &str) -> Result<(), io::E
     }
 }
 
-fn to_op(e: Result<(), io::Error>) -> OpResult {
-    match e {
-        Ok(_) => ok(),
-        Err(e) => Err(ExitError::errmsg(format!("{}", e))),
-    }
-}
-
 /// See the documentation for lorri::cli::Command::Init for
 /// more details
 pub fn main(default_shell: &str, default_envrc: &str) -> OpResult {
-    to_op(create_if_missing(
+    create_if_missing(
         Path::new("./shell.nix"),
         default_shell,
         "shell.nix exists, skipping. Make sure it is of a form that works with nix-shell.",
-    ))?;
+    )
+    .map_err(|e| ExitError::user_error(format!("{}", e)))?;
 
-    to_op(create_if_missing(
+    create_if_missing(
         Path::new("./.envrc"),
         default_envrc,
-        ".envrc exists, skipping. Please add 'eval \"$(lorri direnv)\" to it to set up lorri support.",
-    ))?;
+        ".envrc exists, skipping. Please add 'eval \"$(lorri direnv)\" to it to set up lorri support."
+    ).map_err(|e| ExitError::user_error(format!("{}", e)))?;
 
     ok_msg(String::from("\nSetup done."))
 }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -49,20 +49,19 @@ impl ExitError {
     where
         T: Into<String>,
     {
-        ExitError::err(1, message.into())
+        ExitError {
+            exitcode: 1,
+            message: message.into(),
+        }
     }
 
-    /// Helpers to create exit results
-    ///
-    /// Note: err panics if exitcode is zero.
-    fn err<T>(exitcode: i32, message: T) -> ExitError
+    /// Exit 100 to signify an unexpected crash (lorri bug).
+    pub fn unrecoverable<T>(message: T) -> ExitError
     where
         T: Into<String>,
     {
-        assert!(exitcode != 0, "ExitError exitcode must be > 0!");
-
         ExitError {
-            exitcode,
+            exitcode: 100,
             message: message.into(),
         }
     }
@@ -75,26 +74,5 @@ impl ExitError {
     /// Exit message to be displayed to the user on stderr
     pub fn message(&self) -> &str {
         &self.message
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::ExitError;
-
-    #[test]
-    #[should_panic]
-    fn err_requires_nonzero() {
-        ExitError::err(0, "bogus");
-    }
-
-    #[test]
-    fn getters() {
-        match ExitError::err(1, "bogus") {
-            e => {
-                assert_eq!(e.exitcode(), 1);
-                assert_eq!(e.message(), "bogus");
-            }
-        }
     }
 }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -15,6 +15,13 @@ pub fn get_paths() -> Result<crate::constants::Paths, ExitError> {
 }
 
 /// Non-zero exit status from an op
+///
+/// Based on the execline convention:
+/// All these commands exit
+/// - 1 if they encounter an expected error
+/// - 111 if they encounter a temporary error
+/// - 100 if they encounter a permanent error - such as a misuse
+/// - 127 if they're trying to execute into a program and cannot find it
 #[derive(Debug, Clone)]
 pub struct ExitError {
     /// Exit code of the process, should be non-zero
@@ -62,6 +69,17 @@ impl ExitError {
     {
         ExitError {
             exitcode: 100,
+            message: message.into(),
+        }
+    }
+
+    /// Exit 127 to signify a missing executable.
+    pub fn missing_executable<T>(message: T) -> ExitError
+    where
+        T: Into<String>,
+    {
+        ExitError {
+            exitcode: 127,
             message: message.into(),
         }
     }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -9,131 +9,136 @@ pub mod upgrade;
 pub mod watch;
 
 /// Set up necessary directories or fail.
-pub fn get_paths() -> Result<crate::constants::Paths, ExitError> {
-    crate::constants::Paths::initialize()
-        .map_err(|e| ExitError::user_error(format!("Cannot initialize the lorri paths: {:#?}", e)))
+pub fn get_paths() -> Result<crate::constants::Paths, error::ExitError> {
+    crate::constants::Paths::initialize().map_err(|e| {
+        error::ExitError::user_error(format!("Cannot initialize the lorri paths: {:#?}", e))
+    })
 }
 
-/// Non-zero exit status from an op.
-///
-/// Based in part on the execline convention
-/// (see https://skarnet.org/software/execline/exitcodes.html).
-///
-/// All these commands exit
-/// - 1 if they encounter an expected error
-/// - 100 if they encounter a permanent error – “the user is holding it wrong”
-/// - 101 if they encounter a programming error, like a panic or failed assert
-/// - 111 if they encounter a temporary error, such as resource exhaustion
-/// - 126 if there is a problem with the environment in which lorri is run
-/// - 127 if they're trying to execute into a program and cannot find it
-#[derive(Debug, Clone)]
-pub struct ExitError {
-    /// Exit code of the process, should be non-zero
-    exitcode: i32,
+/// Error handling in ops.
+pub mod error {
 
-    /// Final dying words
-    message: String,
-}
+    /// Non-zero exit status from an op.
+    ///
+    /// Based in part on the execline convention
+    /// (see https://skarnet.org/software/execline/exitcodes.html).
+    ///
+    /// All these commands exit
+    /// - 1 if they encounter an expected error
+    /// - 100 if they encounter a permanent error – “the user is holding it wrong”
+    /// - 101 if they encounter a programming error, like a panic or failed assert
+    /// - 111 if they encounter a temporary error, such as resource exhaustion
+    /// - 126 if there is a problem with the environment in which lorri is run
+    /// - 127 if they're trying to execute into a program and cannot find it
+    #[derive(Debug, Clone)]
+    pub struct ExitError {
+        /// Exit code of the process, should be non-zero
+        exitcode: i32,
 
-/// Final result from a CLI operation
-pub type OpResult = Result<Option<String>, ExitError>;
+        /// Final dying words
+        message: String,
+    }
 
-/// Return an OpResult with a final message to print before exit 0
-/// Note, the final message is possibly intended to be consumed
-/// by automated tests.
-pub fn ok_msg<T>(message: T) -> OpResult
-where
-    T: Into<String>,
-{
-    Ok(Some(message.into()))
-}
+    /// Final result from a CLI operation
+    pub type OpResult = Result<Option<String>, ExitError>;
 
-/// Return an OpResult with no message to be printed, producing
-/// a silent exit 0
-pub fn ok() -> OpResult {
-    Ok(None)
-}
-
-impl ExitError {
-    /// Exit 1 to signify a generic expected error
-    /// (e.g. something that sometimes just goes wrong, like a nix build).
-    pub fn expected_error<T>(message: T) -> ExitError
+    /// Return an OpResult with a final message to print before exit 0
+    /// Note, the final message is possibly intended to be consumed
+    /// by automated tests.
+    pub fn ok_msg<T>(message: T) -> OpResult
     where
         T: Into<String>,
     {
-        ExitError {
-            exitcode: 1,
-            message: message.into(),
+        Ok(Some(message.into()))
+    }
+
+    /// Return an OpResult with no message to be printed, producing
+    /// a silent exit 0
+    pub fn ok() -> OpResult {
+        Ok(None)
+    }
+
+    impl ExitError {
+        /// Exit 1 to signify a generic expected error
+        /// (e.g. something that sometimes just goes wrong, like a nix build).
+        pub fn expected_error<T>(message: T) -> ExitError
+        where
+            T: Into<String>,
+        {
+            ExitError {
+                exitcode: 1,
+                message: message.into(),
+            }
         }
-    }
 
-    /// Exit 100 to signify a user error (“the user is holding it wrong”).
-    /// This is a permanent error, if the program is executed the same way
-    /// it should crash with 100 again.
-    pub fn user_error<T>(message: T) -> ExitError
-    where
-        T: Into<String>,
-    {
-        ExitError {
-            exitcode: 100,
-            message: message.into(),
+        /// Exit 100 to signify a user error (“the user is holding it wrong”).
+        /// This is a permanent error, if the program is executed the same way
+        /// it should crash with 100 again.
+        pub fn user_error<T>(message: T) -> ExitError
+        where
+            T: Into<String>,
+        {
+            ExitError {
+                exitcode: 100,
+                message: message.into(),
+            }
         }
-    }
 
-    /// Exit 101 to signify an unexpected crash (failing assertion or panic).
-    /// This is the same exit code that `panic!()` emits.
-    pub fn panic<T>(message: T) -> ExitError
-    where
-        T: Into<String>,
-    {
-        ExitError {
-            exitcode: 101,
-            message: message.into(),
+        /// Exit 101 to signify an unexpected crash (failing assertion or panic).
+        /// This is the same exit code that `panic!()` emits.
+        pub fn panic<T>(message: T) -> ExitError
+        where
+            T: Into<String>,
+        {
+            ExitError {
+                exitcode: 101,
+                message: message.into(),
+            }
         }
-    }
 
-    /// Exit 111 to signify a temporary error (such as resource exhaustion)
-    pub fn temporary<T>(message: T) -> ExitError
-    where
-        T: Into<String>,
-    {
-        ExitError {
-            exitcode: 111,
-            message: message.into(),
+        /// Exit 111 to signify a temporary error (such as resource exhaustion)
+        pub fn temporary<T>(message: T) -> ExitError
+        where
+            T: Into<String>,
+        {
+            ExitError {
+                exitcode: 111,
+                message: message.into(),
+            }
         }
-    }
 
-    // TODO: combine 126 and 127
-    /// Exit 126 to signify an environment problem
-    /// (the user has set up stuff incorrectly so lorri cannot work)
-    pub fn environment_problem<T>(message: T) -> ExitError
-    where
-        T: Into<String>,
-    {
-        ExitError {
-            exitcode: 126,
-            message: message.into(),
+        // TODO: combine 126 and 127
+        /// Exit 126 to signify an environment problem
+        /// (the user has set up stuff incorrectly so lorri cannot work)
+        pub fn environment_problem<T>(message: T) -> ExitError
+        where
+            T: Into<String>,
+        {
+            ExitError {
+                exitcode: 126,
+                message: message.into(),
+            }
         }
-    }
 
-    /// Exit 127 to signify a missing executable.
-    pub fn missing_executable<T>(message: T) -> ExitError
-    where
-        T: Into<String>,
-    {
-        ExitError {
-            exitcode: 127,
-            message: message.into(),
+        /// Exit 127 to signify a missing executable.
+        pub fn missing_executable<T>(message: T) -> ExitError
+        where
+            T: Into<String>,
+        {
+            ExitError {
+                exitcode: 127,
+                message: message.into(),
+            }
         }
-    }
 
-    /// Exit code of the failure message, guaranteed to be > 0
-    pub fn exitcode(&self) -> i32 {
-        self.exitcode
-    }
+        /// Exit code of the failure message, guaranteed to be > 0
+        pub fn exitcode(&self) -> i32 {
+            self.exitcode
+        }
 
-    /// Exit message to be displayed to the user on stderr
-    pub fn message(&self) -> &str {
-        &self.message
+        /// Exit message to be displayed to the user on stderr
+        pub fn message(&self) -> &str {
+            &self.message
+        }
     }
 }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -107,7 +107,6 @@ pub mod error {
             }
         }
 
-        // TODO: combine 126 and 127
         /// Exit 126 to signify an environment problem
         /// (the user has set up stuff incorrectly so lorri cannot work)
         pub fn environment_problem<T>(message: T) -> ExitError

--- a/src/ops/ping.rs
+++ b/src/ops/ping.rs
@@ -1,6 +1,6 @@
 //! Run a BuildLoop for `shell.nix`, watching for input file changes.
 //! Can be used together with `direnv`.
-use crate::ops::{ok, OpResult};
+use crate::ops::error::{ok, OpResult};
 use crate::NixFile;
 
 use crate::socket::communicate::client;

--- a/src/ops/upgrade/mod.rs
+++ b/src/ops/upgrade/mod.rs
@@ -69,6 +69,7 @@ pub fn main(upgrade_target: cli::UpgradeTo, cas: &ContentAddressable) -> OpResul
                 .arg("--install")
                 .arg(build_result.as_path())
                 .status()
+                // TODO: check existence of commands at the beginning
                 .expect("Error: failed to execute nix-env --install");
             // we can drop the temporary gc root
             drop(gc_root);
@@ -76,15 +77,13 @@ pub fn main(upgrade_target: cli::UpgradeTo, cas: &ContentAddressable) -> OpResul
             if status.success() {
                 Ok(Some(String::from("\nUpgrade successful.")))
             } else {
-                Err(ExitError::errmsg(String::from(
-                    "\nError: nix-env command was not successful!",
+                Err(ExitError::expected_error(format!(
+                    "\nError: nix-env command was not successful!\n{:#?}",
+                    status
                 )))
             }
         }
-        Err(e) => Err(ExitError::errmsg(format!(
-            "Failed to build the update! Please report a bug!\n\
-             {:?}",
-            e
-        ))),
+        // our update expression is broken, crash
+        Err(e) => panic!("Failed to build the update! {:#?}", e),
     }
 }

--- a/src/ops/upgrade/mod.rs
+++ b/src/ops/upgrade/mod.rs
@@ -8,7 +8,7 @@ use crate::cas::ContentAddressable;
 use crate::changelog;
 use crate::cli;
 use crate::nix;
-use crate::ops::{ExitError, OpResult};
+use crate::ops::error::{ExitError, OpResult};
 use crate::VERSION_BUILD_REV;
 use std::process::Command;
 

--- a/src/ops/watch.rs
+++ b/src/ops/watch.rs
@@ -3,7 +3,7 @@
 
 use crate::build_loop::{BuildError, BuildLoop};
 use crate::cli::WatchOptions;
-use crate::ops::{ok, ExitError, OpResult};
+use crate::ops::error::{ok, ExitError, OpResult};
 use crate::project::Project;
 use crossbeam_channel as chan;
 use std::fmt::Debug;

--- a/src/ops/watch.rs
+++ b/src/ops/watch.rs
@@ -27,9 +27,9 @@ fn main_run_once(project: Project) -> OpResult {
             print_build_message(msg);
             ok()
         }
-        Err(BuildError::Unrecoverable(err)) => Err(ExitError::unrecoverable(format!("{:?}", err))),
+        Err(BuildError::Unrecoverable(err)) => Err(ExitError::temporary(format!("{:?}", err))),
         Err(BuildError::Recoverable(exit_failure)) => {
-            Err(ExitError::errmsg(format!("{:#?}", exit_failure)))
+            Err(ExitError::expected_error(format!("{:#?}", exit_failure)))
         }
     }
 }

--- a/src/ops/watch.rs
+++ b/src/ops/watch.rs
@@ -27,7 +27,7 @@ fn main_run_once(project: Project) -> OpResult {
             print_build_message(msg);
             ok()
         }
-        Err(BuildError::Unrecoverable(err)) => Err(ExitError::err(100, format!("{:?}", err))),
+        Err(BuildError::Unrecoverable(err)) => Err(ExitError::unrecoverable(format!("{:?}", err))),
         Err(BuildError::Recoverable(exit_failure)) => {
             Err(ExitError::errmsg(format!("{:#?}", exit_failure)))
         }


### PR DESCRIPTION
This consolidates the `ExitError` type and makes lorri output different error codes depending on which kind of error happened.

Inspired by https://github.com/target/lorri/pull/184, but doesn’t use the code because it takes a slightly different approach.