### PR TITLE
constants/Paths: Split IO errors into enum for easier debugging

### DIFF
--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -11,7 +11,7 @@ pub mod watch;
 /// Set up necessary directories or fail.
 pub fn get_paths() -> Result<crate::constants::Paths, ExitError> {
     crate::constants::Paths::initialize()
-        .map_err(|e| ExitError::errmsg(format!("Cannot initialize the lorri paths: {}", e)))
+        .map_err(|e| ExitError::errmsg(format!("Cannot initialize the lorri paths: {:#?}", e,)))
 }
 
 /// Non-zero exit status from an op


### PR DESCRIPTION
what it says on the tin. Good error messages if something in the user environment is not right.