### PR TITLE
Ci run cachix even on failing checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@
 "matrix":
   "include":
   - "before_cache":
-    - >
-      if [ -n "$CACHIX_SIGNING_KEY" ]; then
-        cachix push lorri-test < $HOME/push-to-cachix
-      fi
     - >-
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/liblorri.rlib"
     - >-
@@ -58,6 +54,16 @@
     - >-
       set -e
     - >-
+      nix-build -A allBuildInputs shell.nix > ./shell-inputs
+    - >-
+      echo "pushing these paths to cachix:"
+    - >-
+      cat ./shell-inputs
+    - >
+      if [ -n "$CACHIX_SIGNING_KEY" ]; then
+        cachix push lorri-test < ./shell-inputs
+      fi
+    - >-
       nix-shell --quiet --arg isDevelopmentShell false --run ci_check
     - >-
       cat $(nix-build --quiet ./.travis.yml.nix --no-out-link) > .travis.yml
@@ -65,10 +71,6 @@
       git diff -q ./.travis.yml
     - >-
       git diff -q ./Cargo.nix
-    - >
-      nix-build -E '(import ./shell.nix { isDevelopmentShell = false; }).buildInputs'
-      \
-        >> $HOME/push-to-cachix
   - "before_cache":
     - >-
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/liblorri.rlib"
@@ -120,6 +122,16 @@
     - >-
       set -e
     - >-
+      nix-build -A allBuildInputs shell.nix > ./shell-inputs
+    - >-
+      echo "pushing these paths to cachix:"
+    - >-
+      cat ./shell-inputs
+    - >
+      if [ -n "$CACHIX_SIGNING_KEY" ]; then
+        cachix push lorri-test < ./shell-inputs
+      fi
+    - >-
       nix-shell --quiet --arg isDevelopmentShell false --run ci_check
     - >-
       cat $(nix-build --quiet ./.travis.yml.nix --no-out-link) > .travis.yml
@@ -127,16 +139,7 @@
       git diff -q ./.travis.yml
     - >-
       git diff -q ./Cargo.nix
-    - >
-      nix-build -E '(import ./shell.nix { isDevelopmentShell = false; }).buildInputs'
-      \
-        >> $HOME/push-to-cachix
-  - "before_cache":
-    - >
-      if [ -n "$CACHIX_SIGNING_KEY" ]; then
-        cachix push lorri-test < $HOME/push-to-cachix
-      fi
-    "install":
+  - "install":
     - >-
       nix-env -iA cachix -f https://cachix.org/api/v1/install
     - >-
@@ -157,9 +160,17 @@
     - >-
       nix-env -i ./result
     - >-
-      lorri self-upgrade local $(pwd)
+      readlink ./result > ./cachix-file
     - >-
-      readlink ./result >> $HOME/push-to-cachix
+      echo "pushing these paths to cachix:"
+    - >-
+      cat ./cachix-file
+    - >
+      if [ -n "$CACHIX_SIGNING_KEY" ]; then
+        cachix push lorri-test < ./cachix-file
+      fi
+    - >-
+      lorri self-upgrade local $(pwd)
   - "before_install":
     - >-
       wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/releases/nix/nix-2.3.1/install
@@ -183,6 +194,14 @@
     - >-
       nix-env -i ./result
     - >-
-      lorri self-upgrade local $(pwd)
+      readlink ./result > ./cachix-file
     - >-
-      readlink ./result >> $HOME/push-to-cachix
+      echo "pushing these paths to cachix:"
+    - >-
+      cat ./cachix-file
+    - >
+      if [ -n "$CACHIX_SIGNING_KEY" ]; then
+        cachix push lorri-test < ./cachix-file
+      fi
+    - >-
+      lorri self-upgrade local $(pwd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,14 +124,6 @@
     - >-
       nix-build -A allBuildInputs shell.nix > ./shell-inputs
     - >-
-      echo "pushing these paths to cachix:"
-    - >-
-      cat ./shell-inputs
-    - >
-      if [ -n "$CACHIX_SIGNING_KEY" ]; then
-        cachix push lorri-test < ./shell-inputs
-      fi
-    - >-
       nix-shell --quiet --arg isDevelopmentShell false --run ci_check
     - >-
       cat $(nix-build --quiet ./.travis.yml.nix --no-out-link) > .travis.yml
@@ -195,13 +187,5 @@
       nix-env -i ./result
     - >-
       readlink ./result > ./cachix-file
-    - >-
-      echo "pushing these paths to cachix:"
-    - >-
-      cat ./cachix-file
-    - >
-      if [ -n "$CACHIX_SIGNING_KEY" ]; then
-        cachix push lorri-test < ./cachix-file
-      fi
     - >-
       lorri self-upgrade local $(pwd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,20 +55,16 @@
     "os": >-
       linux
     "script":
-    - >
+    - >-
       set -e
-
-      source ./.travis_fold.sh
-
-
-      lorri_travis_fold ci_check \
-        nix-shell --quiet --arg isDevelopmentShell false --run ci_check
-      lorri_travis_fold travis-yml-gen \
-        cat $(nix-build --quiet ./.travis.yml.nix --no-out-link) > .travis.yml
-      lorri_travis_fold travis-yml-idempotent \
-        git diff -q ./.travis.yml
-      lorri_travis_fold carnix-idempotent \
-        git diff -q ./Cargo.nix
+    - >-
+      nix-shell --quiet --arg isDevelopmentShell false --run ci_check
+    - >-
+      cat $(nix-build --quiet ./.travis.yml.nix --no-out-link) > .travis.yml
+    - >-
+      git diff -q ./.travis.yml
+    - >-
+      git diff -q ./Cargo.nix
     - >
       nix-build -E '(import ./shell.nix { isDevelopmentShell = false; }).buildInputs'
       \
@@ -97,11 +93,11 @@
     - >-
       rm -rvf "$TRAVIS_BUILD_DIR/target/debug/incremental/direnv-*"
     "before_install":
-    - >
+    - >-
       wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/releases/nix/nix-2.3.1/install
-
+    - >-
       yes | sh /tmp/nix-install --daemon
-
+    - >
       if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
         source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
       elif [ -f ${TRAVIS_HOME}/.nix-profile/etc/profile.d/nix.sh ]; then
@@ -121,20 +117,16 @@
     "os": >-
       osx
     "script":
-    - >
+    - >-
       set -e
-
-      source ./.travis_fold.sh
-
-
-      lorri_travis_fold ci_check \
-        nix-shell --quiet --arg isDevelopmentShell false --run ci_check
-      lorri_travis_fold travis-yml-gen \
-        cat $(nix-build --quiet ./.travis.yml.nix --no-out-link) > .travis.yml
-      lorri_travis_fold travis-yml-idempotent \
-        git diff -q ./.travis.yml
-      lorri_travis_fold carnix-idempotent \
-        git diff -q ./Cargo.nix
+    - >-
+      nix-shell --quiet --arg isDevelopmentShell false --run ci_check
+    - >-
+      cat $(nix-build --quiet ./.travis.yml.nix --no-out-link) > .travis.yml
+    - >-
+      git diff -q ./.travis.yml
+    - >-
+      git diff -q ./Cargo.nix
     - >
       nix-build -E '(import ./shell.nix { isDevelopmentShell = false; }).buildInputs'
       \
@@ -158,25 +150,22 @@
     "os": >-
       linux
     "script":
-    - >
+    - >-
       set -e
-
-      source ./.travis_fold.sh
-
-      lorri_travis_fold lorri-nix-build \
-        nix-build
-      lorri_travis_fold lorri-install \
-        nix-env -i ./result
-      lorri_travis_fold lorri-self-upgrade \
-        lorri self-upgrade local $(pwd)
+    - >-
+      nix-build
+    - >-
+      nix-env -i ./result
+    - >-
+      lorri self-upgrade local $(pwd)
     - >-
       readlink ./result >> $HOME/push-to-cachix
   - "before_install":
-    - >
+    - >-
       wget --retry-connrefused --waitretry=1 -O /tmp/nix-install https://nixos.org/releases/nix/nix-2.3.1/install
-
+    - >-
       yes | sh /tmp/nix-install --daemon
-
+    - >
       if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
         source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
       elif [ -f ${TRAVIS_HOME}/.nix-profile/etc/profile.d/nix.sh ]; then
@@ -187,16 +176,13 @@
     "os": >-
       osx
     "script":
-    - >
+    - >-
       set -e
-
-      source ./.travis_fold.sh
-
-      lorri_travis_fold lorri-nix-build \
-        nix-build
-      lorri_travis_fold lorri-install \
-        nix-env -i ./result
-      lorri_travis_fold lorri-self-upgrade \
-        lorri self-upgrade local $(pwd)
+    - >-
+      nix-build
+    - >-
+      nix-env -i ./result
+    - >-
+      lorri self-upgrade local $(pwd)
     - >-
       readlink ./result >> $HOME/push-to-cachix

--- a/shell.nix
+++ b/shell.nix
@@ -12,6 +12,18 @@ let
         stableVersion = "1.35.0";
       });
 
+  # Lorri-specific
+
+  # The root directory of this project
+  LORRI_ROOT = toString ./.;
+  # Needed by the lorri build.rs to determine its own version
+  # for the development repository (non-release), we set it to 1
+  BUILD_REV_COUNT = 1;
+  # Needed by the lorri build.rs to access some tools used during
+  # the build of lorri's environment derivations.
+  RUN_TIME_CLOSURE = pkgs.callPackage ./nix/runtime.nix {};
+
+
   buildInputs = [
       # This rust comes from the Mozilla rust overlay so we can
       # get Clippy. Not suitable for production builds. See
@@ -40,7 +52,7 @@ let
     allBuildInputs = buildInputs;
 
 in
-pkgs.mkShell rec {
+pkgs.mkShell {
   name = "lorri";
   buildInputs = buildInputs
     ++ pkgs.stdenv.lib.optionals isDevelopmentShell [
@@ -50,16 +62,7 @@ pkgs.mkShell rec {
   # Keep project-specific shell commands local
   HISTFILE = "${toString ./.}/.bash_history";
 
-  # Lorri-specific
-
-  # The root directory of this project
-  LORRI_ROOT = toString ./.;
-  # Needed by the lorri build.rs to determine its own version
-  # for the development repository (non-release), we set it to 1
-  BUILD_REV_COUNT = 1;
-  # Needed by the lorri build.rs to access some tools used during
-  # the build of lorri's environment derivations.
-  RUN_TIME_CLOSURE = pkgs.callPackage ./nix/runtime.nix {};
+  inherit BUILD_REV_COUNT RUN_TIME_CLOSURE;
 
   # Rust-specific
 
@@ -72,7 +75,6 @@ pkgs.mkShell rec {
   RUST_SRC_PATH = "${rustChannels.stable.rust-src}/lib/rustlib/src/rust/src/";
   # Set up a local directory to install binaries in
   CARGO_INSTALL_ROOT = "${LORRI_ROOT}/.cargo";
-
 
   # Executed when entering `nix-shell`
   shellHook = ''


### PR DESCRIPTION
This improves caching in situations where the checks fail (because dependencies are already uploaded to cachix before the checks, which should reduce the turnaround time for PRs, esp. for darwin, considerably.