### PR TITLE
direnv directly from nixos rather than github

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ For Nix on Linux or macOS, you can install the needed version of
 direnv with:
 
 ```
-$ curl -o direnv.nix -L https://github.com/target/lorri/raw/master/direnv/nix.nix
-$ nix-env -if ./direnv.nix
+$ nix-env -iA nixos.direnv
 ```
 
 ### Enable direnv


### PR DESCRIPTION
I'm not 100% sure of this change - but I think it's more ideal as direnv is on direnv-2.20.1 on nixos 19.09 currently (I'm guessing it was an older version on the nixos channel previously).