### PR TITLE
[WIP] readDir: do not watch directories recursively

### DIFF
--- a/src/watch.rs
+++ b/src/watch.rs
@@ -69,9 +69,6 @@ impl Watch {
     pub fn extend(&mut self, paths: &[PathBuf]) -> Result<(), notify::Error> {
         for path in paths {
             self.add_path(&path)?;
-            if path.is_dir() {
-                self.add_path_recursively(&path)?;
-            }
         }
 
         Ok(())
@@ -165,24 +162,6 @@ impl Watch {
                 debug!("watch event: {:#?}", otherwise);
             }
         }
-    }
-
-    fn add_path_recursively(&mut self, path: &PathBuf) -> Result<(), notify::Error> {
-        if path.canonicalize()?.starts_with(Path::new("/nix/store")) {
-            return Ok(());
-        }
-
-        for entry in path.read_dir()? {
-            let subpath = entry?.path();
-
-            if subpath.is_dir() {
-                self.add_path(&subpath)?;
-                self.add_path_recursively(&subpath)?;
-            }
-
-            // Skip adding files, watching in the dir will handle it.
-        }
-        Ok(())
     }
 
     fn add_path(&mut self, path: &PathBuf) -> Result<(), notify::Error> {


### PR DESCRIPTION
**Do not merge.** See https://github.com/target/lorri/pull/232#issuecomment-559839797.

Fixes #152:

> Lorri seems to watch directories recursively when it detects `builtins.readDir`. This seems unnecessary because `readDir` only returns the direct children. Any use of those children should be detectable with existing means.

This "minimal diff" fix changes the following behaviour:
- _previously_ when `lorri` saw a `readDir`, it started watching that directory recursively
- _now_ it just watches that directory.

Note that when watching a directory, `notify` will still tell us when any of its children are updated:

> If `recursive_mode` is `RecursiveMode::Recursive` events will be delivered for all files in that tree. **Otherwise only the directory and its immediate children will be watched.**

https://docs.rs/notify/5.0.0-pre.1/notify/trait.Watcher.html#tymethod.watch

We are not using `RecursiveMode::Recursive` - "only the directory and its immediate children" is what we want here.

See https://github.com/target/lorri/issues/152#issuecomment-555505899.