### PR TITLE
Add sanity checks to investigate #250

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -100,13 +100,23 @@ fn run_command(opts: Arguments) -> OpResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
 
     /// Try instantiating the trivial shell file we provide the user.
     #[test]
     fn trivial_shell_nix() -> std::io::Result<()> {
+        let nixpkgs = "./nix/bogus-nixpkgs/";
+
+        // Sanity check the test environment
+        assert!(Path::new(nixpkgs).is_dir(), "nixpkgs must be a directory");
+        assert!(
+            Path::new(nixpkgs).join("default.nix").is_file(),
+            "nixpkgs/default.nix must be a file"
+        );
+
         let out = std::process::Command::new("nix-instantiate")
             // we can’t assume to have a <nixpkgs>, so use bogus-nixpkgs
-            .args(&["-I", "nixpkgs=./nix/bogus-nixpkgs/"])
+            .args(&["-I", &format!("nixpkgs={}", nixpkgs)])
             .args(&["--expr", TRIVIAL_SHELL_SRC])
             .output()?;
         assert!(


### PR DESCRIPTION
In #250, `nix-instantiate` claims to be unable to find the `nixpkgs` path passed to it. This PR adds assertions to make sure the relevant directory and file do in fact exist. With this PR, it should be very obvious if due to some CI environment setup mistake we have made the `nixpkgs` path unavailable to the test itself.