### PR TITLE
logged-evaluation.nix: support additional servicesSrc argument

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -28,8 +28,8 @@
         # Do an immediate, light-weight test to ensure logged-evaluation
         # is valid, prior to doing expensive compilations.
         nix-build --show-trace ./src/logged-evaluation.nix \
-          --arg src ./tests/integration/basic/shell.nix \
-          --arg runTimeClosure "$RUN_TIME_CLOSURE" \
+          --arg shellSrc ./tests/integration/basic/shell.nix \
+          --arg runtimeClosure "$RUN_TIME_CLOSURE" \
           --no-out-link
       '';
 

--- a/src/build_loop.rs
+++ b/src/build_loop.rs
@@ -85,7 +85,7 @@ impl<'a> BuildLoop<'a> {
 
         // The project has just been added, so run the builder in the first iteration
         let mut reason = Some(Event::Started(Reason::ProjectAdded(
-            self.project.nix_file.clone(),
+            self.project.shell_nix.clone(),
         )));
         let mut output_paths = None;
 
@@ -133,7 +133,7 @@ impl<'a> BuildLoop<'a> {
     pub fn once(&mut self) -> Result<BuildResults, BuildError> {
         let (tx, rx) = chan::unbounded();
         let services_nix = None; // TODO: extend the Project struct to support an optional services_nix
-        let run_result = builder::run(tx, &self.project.nix_file, services_nix, &self.project.cas)?;
+        let run_result = builder::run(tx, &self.project.shell_nix, services_nix, &self.project.cas)?;
 
         self.register_paths(&run_result.referenced_paths)?;
 

--- a/src/build_loop.rs
+++ b/src/build_loop.rs
@@ -132,7 +132,8 @@ impl<'a> BuildLoop<'a> {
     /// the evaluation.
     pub fn once(&mut self) -> Result<BuildResults, BuildError> {
         let (tx, rx) = chan::unbounded();
-        let run_result = builder::run(tx, &self.project.nix_file, &self.project.cas)?;
+        let services_nix = None; // TODO: extend the Project struct to support an optional services_nix
+        let run_result = builder::run(tx, &self.project.nix_file, services_nix, &self.project.cas)?;
 
         self.register_paths(&run_result.referenced_paths)?;
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -86,11 +86,11 @@ fn instrumented_instantiation(
         OsStr::new("--indirect"),
         OsStr::new("--argstr"),
         // runtime nix paths to needed dependencies that come with lorri
-        OsStr::new("runTimeClosure"),
+        OsStr::new("runtimeClosure"),
         OsStr::new(crate::RUN_TIME_CLOSURE),
         // the source file
         OsStr::new("--argstr"),
-        OsStr::new("src"),
+        OsStr::new("shellSrc"),
         root_nix_file.as_os_str(),
         // instrumented by `./logged-evaluation.nix`
         OsStr::new("--"),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -94,11 +94,11 @@ fn instrumented_instantiation(
         OsStr::new("shellSrc"),
         shell_nix.as_os_str(),
     ]);
-    if services_nix.is_some() {
+    if let Some(services_nix) = services_nix {
         cmd.args(&[
             OsStr::new("--argstr"),
             OsStr::new("servicesSrc"),
-            services_nix.unwrap().as_os_str(),
+            services_nix.as_os_str(),
         ]);
     }
     cmd.args(&[

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -95,7 +95,7 @@ impl Daemon {
         let build_tx = self.build_tx.clone();
 
         self.handler_threads
-            .entry(project.nix_file.clone())
+            .entry(project.shell_nix.clone())
             .or_insert_with(|| Handler {
                 tx,
                 _handle: std::thread::spawn(move || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ fn run_command(log: slog::Logger, opts: Arguments) -> OpResult {
     let without_project = || slog_scope::set_global_logger(log.clone());
     let with_project = |nix_file| -> std::result::Result<(Project, GlobalLoggerGuard), ExitError> {
         let project = create_project(&lorri::ops::get_paths()?, get_shell_nix(nix_file)?)?;
-        let guard = slog_scope::set_global_logger(log.new(o!("root" => project.nix_file.clone())));
+        let guard = slog_scope::set_global_logger(log.new(o!("shell" => project.shell_nix.clone())));
         Ok((project, guard))
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,8 @@ fn run_command(log: slog::Logger, opts: Arguments) -> OpResult {
     let without_project = || slog_scope::set_global_logger(log.clone());
     let with_project = |nix_file| -> std::result::Result<(Project, GlobalLoggerGuard), ExitError> {
         let project = create_project(&lorri::ops::get_paths()?, get_shell_nix(nix_file)?)?;
-        let guard = slog_scope::set_global_logger(log.new(o!("shell" => project.shell_nix.clone())));
+        let guard =
+            slog_scope::set_global_logger(log.new(o!("shell" => project.shell_nix.clone())));
         Ok((project, guard))
     };
 

--- a/src/ops/direnv/mod.rs
+++ b/src/ops/direnv/mod.rs
@@ -19,7 +19,7 @@ pub fn main<W: std::io::Write>(project: Project, mut shell_output: W) -> OpResul
     let paths_are_cached: bool = root_paths.all_exist();
     let address = crate::ops::get_paths()?.daemon_socket_address();
     let shell_nix = rpc::ShellNix {
-        path: project.nix_file.to_string(),
+        path: project.shell_nix.to_string(),
     };
 
     let ping_sent = if let Ok(connection) = varlink::Connection::with_address(&address) {

--- a/src/ops/info.rs
+++ b/src/ops/info.rs
@@ -11,7 +11,7 @@ pub fn main(project: project::Project) -> OpResult {
     println!("Lorri Project Configuration");
     println!();
 
-    println!("expression: {}", project.nix_file);
+    println!("expression: {}", project.shell_nix);
 
     ok()
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -11,8 +11,8 @@ use std::path::{Path, PathBuf};
 /// for a given nix file.
 #[derive(Clone)]
 pub struct Project {
-    /// Absolute path to this project’s nix file.
-    pub nix_file: NixFile,
+    /// Absolute path to this project’s shell nix file.
+    pub shell_nix: NixFile,
 
     /// Directory in which this project’s
     /// garbage collection roots are stored.
@@ -30,17 +30,17 @@ impl Project {
     /// and the base GC root directory
     /// (as returned by `Paths.gc_root_dir()`),
     pub fn new(
-        nix_file: NixFile,
+        shell_nix: NixFile,
         gc_root_dir: &Path,
         cas: ContentAddressable,
     ) -> std::io::Result<Project> {
-        let hash = format!("{:x}", md5::compute(nix_file.as_os_str().as_bytes()));
+        let hash = format!("{:x}", md5::compute(shell_nix.as_os_str().as_bytes()));
         let project_gc_root = gc_root_dir.join(&hash).join("gc_root").to_path_buf();
 
         std::fs::create_dir_all(&project_gc_root)?;
 
         Ok(Project {
-            nix_file,
+            shell_nix,
             gc_root_path: project_gc_root,
             hash,
             cas,


### PR DESCRIPTION
**Context:** we're in the process of adding support for `services.nix`, a nix file specifying long-running services that enable / support project development.

This PR contains 100% plumbing. There are zero user facing changes.

In order to evaluate `services.nix` without too much additional overhead, the idea is to coalesce, or batch, the evaluation. That is, if there is both a `shell.nix` and a `services.nix`, they should be evaluated by lorri using a single `nix-instantiate` subprocess whenever necessary.

This PR adds support for a `servicesSrc` argument to `logged-evaluation.nix`. If this argument is used, evaluating `logged-evaluation.nix` will result in two derivations, one for the shell and one for services. This is a first step towards supporting `services.nix` in addition to `shell.nix`.

**Why not split this already large file into multiple files?** I've decided to keep it all in `logged-evaluation.nix` because every additional file would have to be included in the Rust binary using its own `include_str!` (at least the way things are currently set up). This doesn't add all that much to `logged-evaluation.nix` so that seemed fine.