### PR TITLE
Generate services.json

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -28,8 +28,8 @@
         # Do an immediate, light-weight test to ensure logged-evaluation
         # is valid, prior to doing expensive compilations.
         nix-build --show-trace ./src/logged-evaluation.nix \
-          --arg src ./tests/integration/basic/shell.nix \
-          --arg runTimeClosure "$RUN_TIME_CLOSURE" \
+          --arg shellSrc ./tests/integration/basic/shell.nix \
+          --arg runtimeClosure "$RUN_TIME_CLOSURE" \
           --no-out-link
       '';
 

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,13 @@
-{
-  pkgs ? import ./nix/nixpkgs.nix,
-  src ? pkgs.nix-gitignore.gitignoreSource [".git/"] ./.
+{ pkgs ? import ./nix/nixpkgs.nix
+, src ? pkgs.nix-gitignore.gitignoreSource [ ".git/" ] ./.
 }:
-((pkgs.callPackage ./Cargo.nix {
-  cratesIO = pkgs.callPackage ./nix/carnix/crates-io.nix {};
-}).lorri {}).override {
+(
+  (
+    pkgs.callPackage ./Cargo.nix {
+      cratesIO = pkgs.callPackage ./nix/carnix/crates-io.nix {};
+    }
+  ).lorri {}
+).override {
   crateOverrides = pkgs.defaultCrateOverrides // {
     lorri = attrs: {
       name = "lorri";
@@ -33,8 +36,7 @@
           --no-out-link
       '';
 
-      buildInputs = [ pkgs.nix pkgs.direnv pkgs.which pkgs.rustPackages.rustfmt ] ++
-      pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [
+      buildInputs = [ pkgs.nix pkgs.direnv pkgs.which pkgs.rustPackages.rustfmt ] ++ pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [
         pkgs.darwin.cf-private
         pkgs.darwin.Security
         pkgs.darwin.apple_sdk.frameworks.CoreServices

--- a/nix/bogus-nixpkgs/default.nix
+++ b/nix/bogus-nixpkgs/default.nix
@@ -19,14 +19,17 @@ let
   bogusPackage = bogusFO ./builder.sh;
   bogusUnstablePackage = bogusUnstable ./builder.sh;
 
-in {
+in
+{
   mkShell = { name ? "shell", buildInputs ? [], env ? {} }: derivation
-    (env // {
-      inherit name;
-      builder = ./shell-builder.sh;
-      system = builtins.currentSystem;
-      stdenv = ./stdenv;
-    });
+    (
+      env // {
+        inherit name;
+        builder = ./shell-builder.sh;
+        system = builtins.currentSystem;
+        stdenv = ./stdenv;
+      }
+    );
 
   hello = bogusPackage "hello-1.0.0";
 

--- a/nix/fmt.sh
+++ b/nix/fmt.sh
@@ -1,0 +1,30 @@
+# Format nix files and check their formatting.
+#
+# USAGE:
+#     ./nix/fmt.sh [--check]
+# FLAGS:
+#     --check    Only test if the formatter would change the files
+
+#!/usr/bin/env sh
+
+set -euo pipefail
+IFS=$'\n'
+
+# These files are automatically generated.
+ignore=(
+./Cargo.nix
+./nix/carnix/crates-io.nix
+./.travis.yml.nix
+)
+all=($(find . -name '*.nix'))
+check=()
+
+for i in "${all[@]}"; do
+	skip=
+	for j in "${ignore[@]}"; do
+		[[ $i == $j ]] && { skip=1; break; }
+	done
+	[[ -n $skip ]] || check+=("${i}")
+done
+
+echo "${check[@]}" | xargs nixpkgs-fmt ${1-}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -4,4 +4,5 @@ let
     url = "https://github.com/NixOS/nixpkgs/archive/${srcDef.rev}.tar.gz";
     sha256 = srcDef.sha256;
   };
-in import nixpkgs {}
+in
+import nixpkgs {}

--- a/nix/runtime.nix
+++ b/nix/runtime.nix
@@ -1,9 +1,13 @@
 {
   # Plumbing tools:
-  closureInfo, runCommand, writeText, buildEnv,
-
-  # Actual dependencies to propagate:
-  bash, coreutils }:
+  closureInfo
+, runCommand
+, writeText
+, buildEnv
+, # Actual dependencies to propagate:
+  bash
+, coreutils
+}:
 let
   tools = buildEnv {
     name = "lorri-runtime-tools";
@@ -15,19 +19,20 @@ let
   };
 
   closureToNix = runCommand "closure.nix" {}
-  ''
-    (
-      echo '{ dep, ... }: ['
-      sed -E 's/^(.*)$/    (dep \1)/' ${runtimeClosureInfo}/store-paths
-      echo ']'
-    ) > $out
-  '';
+    ''
+      (
+        echo '{ dep, ... }: ['
+        sed -E 's/^(.*)$/    (dep \1)/' ${runtimeClosureInfo}/store-paths
+        echo ']'
+      ) > $out
+    '';
 
   runtimeClosureInfoAsNix = runCommand "runtime-closure.nix" {
     runtime_closure_list = closureToNix;
     tools_build_host = tools;
   }
-  ''
-    substituteAll ${./runtime-closure.nix.template} $out
-  '';
-in runtimeClosureInfoAsNix
+    ''
+      substituteAll ${./runtime-closure.nix.template} $out
+    '';
+in
+runtimeClosureInfoAsNix

--- a/shell.nix
+++ b/shell.nix
@@ -102,6 +102,9 @@ pkgs.mkShell (
 
         set -x
 
+        lorri_travis_fold fmt-nix ./nix/fmt.sh --check
+        nix_fmt=$?
+
         lorri_travis_fold carnix-update ./nix/update-carnix.sh
         carnixupdate=$?
 
@@ -120,13 +123,14 @@ pkgs.mkShell (
         cargoclippyexit=$?
 
         set +x
+        echo "./nix/fmt.sh --check: $nix_fmt"
         echo "carnix update: $carnixupdates"
         echo "script tests: $scripttests"
         echo "cargo test: $cargotestexit"
         echo "cargo fmt: $cargofmtexit"
         echo "cargo clippy: $cargoclippyexit"
 
-        sum=$((carnixupdate + scripttest + cargotestexit + cargofmtexit + cargoclippyexit))
+        sum=$((nix_fmt + carnixupdate + scripttest + cargotestexit + cargofmtexit + cargoclippyexit))
         if [ "$sum" -gt 0 ]; then
           return 1
         fi

--- a/shell.nix
+++ b/shell.nix
@@ -47,6 +47,7 @@ let
       pkgs.shellcheck
       pkgs.carnix
       pkgs.nix-prefetch-git
+      pkgs.nixpkgs-fmt
 
       # To ensure we always have a compatible nix in our shells.
       # Travis doesn’t know `nix-env` otherwise.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -86,11 +86,11 @@ fn instrumented_instantiation(
         OsStr::new("--indirect"),
         OsStr::new("--argstr"),
         // runtime nix paths to needed dependencies that come with lorri
-        OsStr::new("runTimeClosure"),
+        OsStr::new("runtimeClosure"),
         OsStr::new(crate::RUN_TIME_CLOSURE),
         // the source file
         OsStr::new("--argstr"),
-        OsStr::new("src"),
+        OsStr::new("shellSrc"),
         root_nix_file.as_os_str(),
         // instrumented by `./logged-evaluation.nix`
         OsStr::new("--"),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -91,7 +91,7 @@ fn instrumented_instantiation(
         // the source file
         OsStr::new("--argstr"),
         OsStr::new("shellSrc"),
-        root_nix_file.as_os_str(),
+        PathBuf::from(root_nix_file).as_os_str(),
         // instrumented by `./logged-evaluation.nix`
         OsStr::new("--"),
         &logged_evaluation_nix.as_os_str(),
@@ -491,7 +491,7 @@ in {}
         let (tx, rx) = chan::unbounded();
         let info = run(
             tx,
-            &crate::NixFile::from(cas.file_from_string(&nix_drv)?),
+            &crate::NixFile::Shell(cas.file_from_string(&nix_drv)?),
             &cas,
         )
         .unwrap();
@@ -526,7 +526,7 @@ in {}
         let tmp = tempfile::tempdir()?;
         let cas = ContentAddressable::new(tmp.path().to_owned())?;
 
-        let d = crate::NixFile::from(cas.file_from_string(&drv(
+        let d = crate::NixFile::Shell(cas.file_from_string(&drv(
             "shell",
             &format!("dep = {};", drv("dep", r##"args = [ "-c" "exit 1" ];"##)),
         ))?);
@@ -584,7 +584,7 @@ dir-as-source = ./dir;
         let cas = ContentAddressable::new(cas_tmp.path().join("cas"))?;
 
         let (tx, rx) = chan::unbounded();
-        let inst_info = instrumented_instantiation(tx, &NixFile::from(shell), &cas).unwrap();
+        let inst_info = instrumented_instantiation(tx, &NixFile::Shell(shell), &cas).unwrap();
         let ends_with = |end| inst_info.referenced_paths.iter().any(|p| p.ends_with(end));
         assert!(
             ends_with("foo/default.nix"),

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -75,11 +75,11 @@ impl rpc::VarlinkInterface for Server {
     }
 }
 
-impl std::convert::TryFrom<NixFile> for rpc::ShellNix {
+impl std::convert::TryFrom<&NixFile> for rpc::ShellNix {
     type Error = &'static str;
 
-    fn try_from(nix_file: NixFile) -> Result<Self, Self::Error> {
-        match nix_file.as_os_str().to_str() {
+    fn try_from(nix_file: &NixFile) -> Result<Self, Self::Error> {
+        match PathBuf::from(nix_file).as_os_str().to_str() {
             Some(s) => Ok(rpc::ShellNix {
                 path: s.to_string(),
             }),
@@ -94,7 +94,7 @@ impl std::convert::TryFrom<rpc::ShellNix> for NixFile {
     fn try_from(shell_nix: rpc::ShellNix) -> Result<Self, Self::Error> {
         let path = PathBuf::from(shell_nix.path);
         if path.as_path().is_file() {
-            Ok(NixFile::from(path))
+            Ok(NixFile::Shell(path))
         } else {
             Err(format!("nix file {} does not exist", path.display()))
         }

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -79,11 +79,14 @@ impl std::convert::TryFrom<&NixFile> for rpc::ShellNix {
     type Error = &'static str;
 
     fn try_from(nix_file: &NixFile) -> Result<Self, Self::Error> {
-        match PathBuf::from(nix_file).as_os_str().to_str() {
-            Some(s) => Ok(rpc::ShellNix {
-                path: s.to_string(),
-            }),
-            None => Err("nix file path is not UTF-8 clean"),
+        match nix_file {
+            NixFile::Shell(shell) => match shell.as_os_str().to_str() {
+                Some(s) => Ok(rpc::ShellNix {
+                    path: s.to_string(),
+                }),
+                None => Err("nix file path is not UTF-8 clean"),
+            },
+            NixFile::Services(_) => Err("need a shell nix file, not a services nix file"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,13 +75,6 @@ impl From<&NixFile> for PathBuf {
     }
 }
 
-/// Proxy through the `Display` class for `PathBuf`.
-impl std::fmt::Display for NixFile {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        PathBuf::from(self).display().fmt(f)
-    }
-}
-
 impl slog::Value for NixFile {
     fn serialize(
         &self,

--- a/src/logged-evaluation.nix
+++ b/src/logged-evaluation.nix
@@ -1,4 +1,11 @@
-{ shellSrc ? null, servicesSrc ? null, runtimeClosure }:
+# The purpose of this function is as follows:
+# 1. It protects the output paths of its dependencies from being garbage collected.
+# 2. Given 'shellSrc', it generates a shell environment by capturing environment variables in $out/bash-export.
+# 3. Given 'servicesSrc', it generates a services.json file.
+{ shellSrc ? null # Nix file describing a shell environment
+, servicesSrc ? null # Nix file containing a list of services
+, runtimeClosure
+}:
 assert shellSrc != null || servicesSrc != null;
 let
   runtimeCfg = import runtimeClosure;
@@ -26,7 +33,7 @@ let
   # However, the output paths referenced in any of the drvs are NOT
   # protected.
   #
-  # The keep-env-hack function takes a given derivation and replaces
+  # The wrapped-project function takes a given derivation and replaces
   # its builder with an `env` dumper.
   #
   # gc rooting the resulting store path from this build will retain

--- a/src/logged-evaluation.nix
+++ b/src/logged-evaluation.nix
@@ -31,30 +31,30 @@ let
   # gc rooting the resulting store path from this build will retain
   # references to all the store paths needed, preventing the shell's
   # actual environment from being deleted.
-  wrapped-project = drv: services: derivation (
-    drv.drvAttrs // {
-      name = "lorri-wrapped-project-${drv.name}";
+  wrapped-project = shell: services: derivation (
+    shell.drvAttrs // {
+      name = "lorri-wrapped-project-${shell.name}";
 
-      origExtraClosure = drv.extraClosure or [];
+      origExtraClosure = shell.extraClosure or [];
       extraClosure = runtimeCfg.closure;
 
-      origBuilder = drv.builder;
+      origBuilder = shell.builder;
       builder = runtimeCfg.builder;
 
-      origSystem = drv.system;
+      origSystem = shell.system;
       system = builtins.currentSystem;
 
-      origPATH = drv.PATH or "";
+      origPATH = shell.PATH or "";
       PATH = runtimeCfg.path;
 
       # The derivation we're examining may be multi-output. However,
       # this builder only produces the «out» output. Not specifying a
       # single output means we would fail to start a shell for those
       # projects.
-      origOutputs = drv.outputs or [];
+      origOutputs = shell.outputs or [];
       outputs = [ "out" ];
 
-      origPreHook = drv.preHook or "";
+      origPreHook = shell.preHook or "";
       preHook = ''
         # Redefine addToSearchPathWithCustomDelimiter to integrate with
         # lorri's environment variable setup map. Then, call the original
@@ -108,10 +108,10 @@ let
           }
         fi
 
-        ${drv.preHook or ""}
+        ${shell.preHook or ""}
       '';
 
-      origArgs = drv.args or [];
+      origArgs = shell.args or [];
       args = [
         "-e"
         (

--- a/src/logged-evaluation.nix
+++ b/src/logged-evaluation.nix
@@ -1,4 +1,5 @@
-{ shellSrc, servicesSrc ? null, runtimeClosure }:
+{ shellSrc ? null, servicesSrc ? null, runtimeClosure }:
+assert shellSrc != null || servicesSrc != null;
 let
   runtimeCfg = import runtimeClosure;
 
@@ -32,16 +33,16 @@ let
   # references to all the store paths needed, preventing the shell's
   # actual environment from being deleted.
   wrapped-project = shell: services: derivation (
-    shell.drvAttrs // {
-      name = "lorri-wrapped-project-${shell.name}";
+    (shell.drvAttrs or {}) // {
+      name = "lorri-wrapped-project-${shell.name or "unknown"}";
 
       origExtraClosure = shell.extraClosure or [];
       extraClosure = runtimeCfg.closure;
 
-      origBuilder = shell.builder;
+      origBuilder = shell.builder or null;
       builder = runtimeCfg.builder;
 
-      origSystem = shell.system;
+      origSystem = shell.system or null;
       system = builtins.currentSystem;
 
       origPATH = shell.PATH or "";
@@ -133,8 +134,8 @@ let
              runHook shellHook;
             fi;
 
-            export > $out/bash-export
-            cat << 'EOF' > $out/services.json
+            export > "$out/bash-export"
+            cat << 'EOF' > "$out/services.json"
             ${builtins.toJSON services}
             EOF
           ''
@@ -147,6 +148,7 @@ let
     }
   );
 
+  shell = if shellSrc == null then {} else logged shellSrc;
   services = if servicesSrc == null then [] else logged servicesSrc;
 in
-wrapped-project (logged shellSrc) services
+wrapped-project shell services

--- a/src/logged-evaluation.nix
+++ b/src/logged-evaluation.nix
@@ -16,9 +16,10 @@ let
   imported =
     let
       raw = overrides.scopedImport overrides src;
-    in if (builtins.isFunction raw)
-    then raw {}
-    else raw;
+    in
+      if (builtins.isFunction raw)
+      then raw {}
+      else raw;
 
   # If you add a .drv to a gc-root, the `.drv` itself is protected
   # from GC, and the parent `drv`s up the tree are also protected.
@@ -31,112 +32,120 @@ let
   # gc rooting the resulting store path from this build will retain
   # references to all the store paths needed, preventing the shell's
   # actual environment from being deleted.
-  keep-env-hack = drv: derivation (drv.drvAttrs // {
-    name = "lorri-keep-env-hack-${drv.name}";
+  keep-env-hack = drv: derivation (
+    drv.drvAttrs // {
+      name = "lorri-keep-env-hack-${drv.name}";
 
-    origExtraClosure = drv.extraClosure or [];
-    extraClosure = runtimeCfg.closure;
+      origExtraClosure = drv.extraClosure or [];
+      extraClosure = runtimeCfg.closure;
 
-    origBuilder = drv.builder;
-    builder = runtimeCfg.builder;
+      origBuilder = drv.builder;
+      builder = runtimeCfg.builder;
 
-    origSystem = drv.system;
-    system = builtins.currentSystem;
+      origSystem = drv.system;
+      system = builtins.currentSystem;
 
-    origPATH = drv.PATH or "";
-    PATH = runtimeCfg.path;
+      origPATH = drv.PATH or "";
+      PATH = runtimeCfg.path;
 
-    # The derivation we're examining may be multi-output. However,
-    # this builder only produces the «out» output. Not specifying a
-    # single output means we would fail to start a shell for those
-    # projects.
-    origOutputs = drv.outputs or [];
-    outputs = [ "out" ];
+      # The derivation we're examining may be multi-output. However,
+      # this builder only produces the «out» output. Not specifying a
+      # single output means we would fail to start a shell for those
+      # projects.
+      origOutputs = drv.outputs or [];
+      outputs = [ "out" ];
 
-    origPreHook = drv.preHook or "";
-    preHook = ''
-      # Redefine addToSearchPathWithCustomDelimiter to integrate with
-      # lorri's environment variable setup map. Then, call the original
-      # function. (dirty bash hack.)
-      if declare -f addToSearchPathWithCustomDelimiter > /dev/null 2>&1 ; then
-        # 1. Fetch the function body's definition using `head` and `tail`
-        # 2. Define our own version of the function, which
-        # 3. adds to the `varmap-v1` file the arguments, and
-        # 4. calls the original function's body
-        #
-        # For example on how the `head | tail` bits work:
-        #
-        #     $ foo() { echo foo; }
-        #
-        #     $ declare -f foo
-        #     foo ()
-        #     {
-        #         echo foo
-        #     }
-        #
-        #     $ declare -f foo | head -n-1 | tail -n+3
-        #         echo foo
-        #
-        # While yes it is dirty, we have a precisely pinned version of
-        # bash which we can count on. Thus, if there is a problem or
-        # change in output, it will occur in CI, and not on a customer
-        # machine.
+      origPreHook = drv.preHook or "";
+      preHook = ''
+        # Redefine addToSearchPathWithCustomDelimiter to integrate with
+        # lorri's environment variable setup map. Then, call the original
+        # function. (dirty bash hack.)
+        if declare -f addToSearchPathWithCustomDelimiter > /dev/null 2>&1 ; then
+          # 1. Fetch the function body's definition using `head` and `tail`
+          # 2. Define our own version of the function, which
+          # 3. adds to the `varmap-v1` file the arguments, and
+          # 4. calls the original function's body
+          #
+          # For example on how the `head | tail` bits work:
+          #
+          #     $ foo() { echo foo; }
+          #
+          #     $ declare -f foo
+          #     foo ()
+          #     {
+          #         echo foo
+          #     }
+          #
+          #     $ declare -f foo | head -n-1 | tail -n+3
+          #         echo foo
+          #
+          # While yes it is dirty, we have a precisely pinned version of
+          # bash which we can count on. Thus, if there is a problem or
+          # change in output, it will occur in CI, and not on a customer
+          # machine.
 
-        lorri_addToSearchPathWithCustomDelimiter="$(declare -f addToSearchPathWithCustomDelimiter | head -n-1 | tail -n+3)"
-        addToSearchPathWithCustomDelimiter() {
-          local delimiter=$1
-          local varname=$2
-          local already_present=0
+          lorri_addToSearchPathWithCustomDelimiter="$(declare -f addToSearchPathWithCustomDelimiter | head -n-1 | tail -n+3)"
+          addToSearchPathWithCustomDelimiter() {
+            local delimiter=$1
+            local varname=$2
+            local already_present=0
 
-          while IFS="" read -r -d "" map_instruction \
-             && IFS="" read -r -d "" match_varname \
-             && IFS="" read -r -d "" match_delimiter; do
-            unset IFS
-            if [[ $match_varname == $varname &&
-                  $match_delimiter == $delimiter ]]; then
-              already_present=1
-              break
+            while IFS="" read -r -d "" map_instruction \
+               && IFS="" read -r -d "" match_varname \
+               && IFS="" read -r -d "" match_delimiter; do
+              unset IFS
+              if [[ $match_varname == $varname &&
+                    $match_delimiter == $delimiter ]]; then
+                already_present=1
+                break
+              fi
+            done < $out/varmap-v1
+
+            if [ $already_present -eq 0 ]; then
+              printf 'append\0%s\0%s\0' "$varname" "$delimiter" >> $out/varmap-v1
             fi
-          done < $out/varmap-v1
 
-          if [ $already_present -eq 0 ]; then
-            printf 'append\0%s\0%s\0' "$varname" "$delimiter" >> $out/varmap-v1
-          fi
+            eval "$lorri_addToSearchPathWithCustomDelimiter"
+          }
+        fi
 
-          eval "$lorri_addToSearchPathWithCustomDelimiter"
-        }
-      fi
+        ${drv.preHook or ""}
+      '';
 
-      ${drv.preHook or ""}
-    '';
+      origArgs = drv.args or [];
+      args = [
+        "-e"
+        (
+          builtins.toFile "lorri-keep-env-hack" ''
+            mkdir -p "$out"
+            touch "$out/varmap-v1"
 
-    origArgs = drv.args or [];
-    args = [ "-e" (builtins.toFile "lorri-keep-env-hack" ''
-      mkdir -p "$out"
-      touch "$out/varmap-v1"
+            # Export IN_NIX_SHELL to trick various Nix tooling to export
+            # shell-friendly variables
 
-      # Export IN_NIX_SHELL to trick various Nix tooling to export
-      # shell-friendly variables
+            export IN_NIX_SHELL=impure
 
-      export IN_NIX_SHELL=impure
+            # https://github.com/NixOS/nix/blob/92d08c02c84be34ec0df56ed718526c382845d1a/src/nix-build/nix-build.cc#
+            [ -e $stdenv/setup ] && . $stdenv/setup
 
-      # https://github.com/NixOS/nix/blob/92d08c02c84be34ec0df56ed718526c382845d1a/src/nix-build/nix-build.cc#
-      [ -e $stdenv/setup ] && . $stdenv/setup
+            # target/lorri#23
+            # https://github.com/NixOS/nix/blob/bfc6bdf222d00d3cb1b0e168a5d55d1a7c9cdb72/src/nix-build/nix-build.cc#L424
+            if [ "$(type -t runHook)" = function ]; then
+             runHook shellHook;
+            fi;
 
-      # target/lorri#23
-      # https://github.com/NixOS/nix/blob/bfc6bdf222d00d3cb1b0e168a5d55d1a7c9cdb72/src/nix-build/nix-build.cc#L424
-      if [ "$(type -t runHook)" = function ]; then
-       runHook shellHook;
-      fi;
+            export > $out/bash-export
+          ''
+        )
+      ];
 
-      export > $out/bash-export
-    '') ];
-
-    # Because it’s a trivially lightweight drv, we should never substitute.
-    preferLocalBuild = true;
-    allowSubstitutes = false;
-  });
+      # Because it’s a trivially lightweight drv, we should never substitute.
+      preferLocalBuild = true;
+      allowSubstitutes = false;
+    }
+  );
 
   gc-root = keep-env-hack imported;
 
-in gc-root
+in
+gc-root

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,8 +88,8 @@ fn run_command(log: slog::Logger, opts: Arguments) -> OpResult {
 
     match opts.command {
         Command::Info(opts) => {
-            let (project, _guard) = with_project(&opts.nix_file)?;
-            info::main(project)
+            let (_project, _guard) = with_project(&opts.nix_file)?;
+            info::main(opts.nix_file)
         }
         Command::Direnv(opts) => {
             let (project, _guard) = with_project(&opts.nix_file)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
 /// Try to read `shell.nix` from the current working dir.
 fn get_shell_nix(shellfile: &PathBuf) -> Result<NixFile, ExitError> {
     // use shell.nix from cwd
-    Ok(NixFile::from(locate_file::in_cwd(&shellfile).map_err(
+    Ok(NixFile::Shell(locate_file::in_cwd(&shellfile).map_err(
         |_| {
             ExitError::user_error(format!(
                 "`{}` does not exist\n\

--- a/src/ops/info.rs
+++ b/src/ops/info.rs
@@ -1,17 +1,17 @@
 //! The info callable is for printing
 
 use crate::ops::error::{ok, OpResult};
-use crate::project;
 use crate::VERSION_BUILD_REV;
+use std::path::PathBuf;
 
 /// See the documentation for lorri::cli::Command::Info for more
 /// details.
-pub fn main(project: project::Project) -> OpResult {
+pub fn main(shell_nix: PathBuf) -> OpResult {
     println!("lorri version: {}", VERSION_BUILD_REV);
     println!("Lorri Project Configuration");
     println!();
 
-    println!("expression: {}", project.nix_file);
+    println!("expression: {}", shell_nix.display());
 
     ok()
 }

--- a/src/ops/ping.rs
+++ b/src/ops/ping.rs
@@ -9,7 +9,7 @@ use std::convert::TryFrom;
 pub fn main(nix_file: NixFile) -> OpResult {
     // TODO: set up socket path, make it settable by the user
     let address = crate::ops::get_paths()?.daemon_socket_address();
-    let shell_nix = rpc::ShellNix::try_from(nix_file).unwrap();
+    let shell_nix = rpc::ShellNix::try_from(&nix_file).unwrap();
 
     use rpc::VarlinkClientInterface;
     rpc::VarlinkClient::new(

--- a/src/ops/upgrade/upgrade.nix
+++ b/src/ops/upgrade/upgrade.nix
@@ -3,7 +3,8 @@
   #
   # Calling this with `--argstr src $(pwd)` will install the version
   # of lorri present in $(pwd).
-  src ? "rolling-release",
+  src ? "rolling-release"
+,
 }:
 let
   inherit (builtins) fetchGit hasAttr getAttr trace;
@@ -23,6 +24,7 @@ let
   };
 
   path = if hasAttr src sources
-    then getAttr src sources
-    else sources.local;
-in (import "${path}/release.nix" { src = path; } )
+  then getAttr src sources
+  else sources.local;
+in
+(import "${path}/release.nix" { src = path; })

--- a/src/project.rs
+++ b/src/project.rs
@@ -34,7 +34,10 @@ impl Project {
         gc_root_dir: &Path,
         cas: ContentAddressable,
     ) -> std::io::Result<Project> {
-        let hash = format!("{:x}", md5::compute(nix_file.as_os_str().as_bytes()));
+        let hash = format!(
+            "{:x}",
+            md5::compute(PathBuf::from(&nix_file).as_os_str().as_bytes())
+        );
         let project_gc_root = gc_root_dir.join(&hash).join("gc_root").to_path_buf();
 
         std::fs::create_dir_all(&project_gc_root)?;

--- a/src/trivial-shell.nix
+++ b/src/trivial-shell.nix
@@ -1,8 +1,8 @@
 let
   pkgs = import <nixpkgs> {};
 in
-  pkgs.mkShell {
-    buildInputs = [
-        pkgs.hello
-    ];
-  }
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.hello
+  ];
+}

--- a/tests/integration/direnvtestcase.rs
+++ b/tests/integration/direnvtestcase.rs
@@ -31,7 +31,7 @@ impl DirenvTestCase {
         let test_root =
             PathBuf::from_iter(&[env!("CARGO_MANIFEST_DIR"), "tests", "integration", name]);
 
-        let shell_file = NixFile::from(test_root.join("shell.nix"));
+        let shell_file = NixFile::Shell(test_root.join("shell.nix"));
 
         let cas = ContentAddressable::new(cachedir.path().join("cas").to_owned()).unwrap();
         let project = Project::new(


### PR DESCRIPTION
**Motivation:** we want to be able to generate a `services.json` file based on a nix file. This `services.json` is meant to be consumed by the `lorri services` client to start and stop development services.

On the Nix side, this makes both `shellSrc` and `servicesSrc` optional; at least one of them must be provided.

On the Rust side, `NixFile` is now an enum with possible values `NixFile::Shell(PathBuf)` and `NixFile::Services(PathBuf)`.

**Todo**
- [x] Test `builder::run` with `NixFile::Services`
- [x] Check nix file formatting in CI