### PR TITLE
No clippy on macOS CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ matrix:
     script:
     - set -e
     - nix-build -A allBuildInputs shell.nix > ./shell-inputs
-    - nix-shell --quiet --arg isDevelopmentShell false --run ci_check
+    - nix-shell --quiet --arg isDevelopmentShell false --run ci_test
     - cat $(nix-build --quiet ./.travis.yml.nix --no-out-link) > .travis.yml
     - git diff -q ./.travis.yml
     - git diff -q ./Cargo.nix

--- a/nix/fmt.sh
+++ b/nix/fmt.sh
@@ -14,7 +14,6 @@ IFS=$'\n'
 ignore=(
 ./Cargo.nix
 ./nix/carnix/crates-io.nix
-./.travis.yml.nix
 )
 all=($(find . -name '*.nix'))
 check=()

--- a/shell.nix
+++ b/shell.nix
@@ -38,16 +38,13 @@ let
 
   buildInputs = [
     pkgs.cargo
-    pkgs.rustPackages.clippy
     pkgs.rustc
     pkgs.rustfmt
     pkgs.bashInteractive
     pkgs.git
     pkgs.direnv
     pkgs.shellcheck
-    pkgs.carnix
     pkgs.nix-prefetch-git
-    pkgs.nixpkgs-fmt
 
     # To ensure we always have a compatible nix in our shells.
     # Travis doesn’t know `nix-env` otherwise.
@@ -56,6 +53,19 @@ let
     pkgs.darwin.Security
     pkgs.darwin.apple_sdk.frameworks.CoreServices
     pkgs.darwin.apple_sdk.frameworks.CoreFoundation
+  ] ++ pkgs.stdenv.lib.optionals (!pkgs.stdenv.isDarwin) [
+    # Cachix is broken on macOS [1] and clippy is not built by Hydra [2].
+    # Building clippy and carnix on macOS in CI takes about 25 minutes, so we
+    # don't run lints (which require clippy) on macOS.
+    #
+    # [1] https://github.com/cachix/cachix/issues/228#issuecomment-533634704
+    # [2] https://github.com/NixOS/nixpkgs/issues/77358
+    pkgs.rustPackages.clippy
+    pkgs.carnix
+
+    # These other tools are also used only for linting, and are thus not
+    # required on macOS.
+    pkgs.nixpkgs-fmt
   ];
 
   # we manually collect all build inputs,


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->
Partial workaround for https://github.com/target/lorri/issues/258.

## Overview

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/CONTRIBUTING.md for more on how to structure a pull request.
-->

Cachix does not work on macOS (https://github.com/cachix/cachix/issues/228) and Hydra does not successfully build `clippy` (https://github.com/NixOS/nixpkgs/pull/77327, https://github.com/NixOS/nixpkgs/issues/77358). As a result, in order to run `clippy`, we build it from scratch on every CI run on macOS. This adds about 20 minutes of build time.

There is no need to run `clippy` both on macOS and on Linux. So to circumvent this issue, this PR changes the CI setup slightly so that lints (including `clippy`) are only run on Linux.

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [x] Updated the documentation (code documentation, command help, ...)
- [x] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

