### PR TITLE
shell.nix: remove unsupported "newlorri" alias

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -97,7 +97,6 @@ pkgs.mkShell (
       # nix-shell, you don't need this.
       export SHELL="${pkgs.bashInteractive}/bin/bash";
 
-      alias newlorri="(cd $LORRI_ROOT; cargo run -- shell)"
       alias ci="ci_check"
 
       # this is mirrored from .envrc to make available from nix-shell


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->

## Overview

`lorri shell` does not exist, so the `newlorri` alias does not work.

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/CONTRIBUTING.md for more on how to structure a pull request.
-->

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [ ] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

