### PR TITLE
Remove direnv, which from buildInputs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -36,9 +36,12 @@
           --no-out-link
       '';
 
-      buildInputs = [ pkgs.nix pkgs.direnv pkgs.which pkgs.rustPackages.rustfmt ] ++ pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [
-        pkgs.darwin.Security
-        pkgs.darwin.apple_sdk.frameworks.CoreServices
+      buildInputs = with pkgs; [
+        nix # required for the preConfigure test
+        rustPackages.rustfmt
+      ] ++ stdenv.lib.optionals stdenv.isDarwin [
+        darwin.Security
+        darwin.apple_sdk.frameworks.CoreServices
       ];
     };
   };


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/77380#discussion_r364849796 and https://github.com/NixOS/nixpkgs/commit/c976dc165b69c30f54d8fd42ec541285c598a345#diff-cf738915a62799c87e7c6834f40c3fcd

<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->

## Overview

`nix`, `which` and `direnv` are required for testing and for the successful execution of the daemon, but they are not build inputs for lorri.

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/CONTRIBUTING.md for more on how to structure a pull request.
-->

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [ ] Updated the documentation (code documentation, command help, ...)
- [x] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

