### PR TITLE
info command: show gc roots

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,7 +62,10 @@ pub struct DirenvOptions {
 #[derive(StructOpt, Debug)]
 pub struct InfoOptions {
     /// The .nix file in the current directory to use
-    #[structopt(long = "shell-file", parse(from_os_str), default_value = "shell.nix")]
+    // The "shell-file" argument has no default value. That's on purpose: sometimes users have
+    // projects with multiple shell files. This way, they are forced to think about which shell
+    // file was causing problems when they submit a bug report.
+    #[structopt(long = "shell-file", parse(from_os_str))]
     pub nix_file: PathBuf,
 }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -22,5 +22,5 @@ pub fn root(verbosity: u8, command: &Command) -> slog::Logger {
         .overflow_strategy(slog_async::OverflowStrategy::Block)
         .build()
         .fuse();
-    slog::Logger::root(drain, slog::o!("lorri_version" => crate::VERSION_BUILD_REV))
+    slog::Logger::root(drain, slog::o!())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,14 +77,14 @@ fn run_command(log: slog::Logger, opts: Arguments) -> OpResult {
     let without_project = || slog_scope::set_global_logger(log.clone());
     let with_project = |nix_file| -> std::result::Result<(Project, GlobalLoggerGuard), ExitError> {
         let project = create_project(&lorri::ops::get_paths()?, get_shell_nix(nix_file)?)?;
-        let guard = slog_scope::set_global_logger(log.new(o!("root" => project.nix_file.clone())));
+        let guard = slog_scope::set_global_logger(log.new(o!("expr" => project.nix_file.clone())));
         Ok((project, guard))
     };
 
     match opts.command {
         Command::Info(opts) => {
-            let (_project, _guard) = with_project(&opts.nix_file)?;
-            info::main(opts.nix_file)
+            let (project, _guard) = with_project(&opts.nix_file)?;
+            info::main(project)
         }
         Command::Direnv(opts) => {
             let (project, _guard) = with_project(&opts.nix_file)?;

--- a/src/ops/info.rs
+++ b/src/ops/info.rs
@@ -8,6 +8,7 @@ use slog_scope::info;
 /// See the documentation for lorri::cli::Command::Info for more
 /// details.
 pub fn main(project: Project) -> OpResult {
+    info!("lorri version: {}", crate::VERSION_BUILD_REV);
     let root_paths = Roots::from_project(&project).paths();
     let OutputPaths { shell_gc_root } = &root_paths;
     if root_paths.all_exist() {

--- a/src/ops/info.rs
+++ b/src/ops/info.rs
@@ -1,17 +1,19 @@
 //! The info callable is for printing
 
+use crate::builder::OutputPaths;
 use crate::ops::error::{ok, OpResult};
-use crate::VERSION_BUILD_REV;
-use std::path::PathBuf;
+use crate::project::{roots::Roots, Project};
+use slog_scope::info;
 
 /// See the documentation for lorri::cli::Command::Info for more
 /// details.
-pub fn main(shell_nix: PathBuf) -> OpResult {
-    println!("lorri version: {}", VERSION_BUILD_REV);
-    println!("Lorri Project Configuration");
-    println!();
-
-    println!("expression: {}", shell_nix.display());
-
+pub fn main(project: Project) -> OpResult {
+    let root_paths = Roots::from_project(&project).paths();
+    let OutputPaths { shell_gc_root } = &root_paths;
+    if root_paths.all_exist() {
+        info!("gc roots exist"; "shell_gc_root" => ?shell_gc_root.as_os_str());
+    } else {
+        info!("gc roots do not exist"; "shell_gc_root" => ?shell_gc_root.as_os_str());
+    }
     ok()
 }

--- a/src/ops/info.rs
+++ b/src/ops/info.rs
@@ -3,18 +3,23 @@
 use crate::builder::OutputPaths;
 use crate::ops::error::{ok, OpResult};
 use crate::project::{roots::Roots, Project};
-use slog_scope::info;
 
 /// See the documentation for lorri::cli::Command::Info for more
 /// details.
 pub fn main(project: Project) -> OpResult {
-    info!("lorri version: {}", crate::VERSION_BUILD_REV);
+    println!("lorri version: {}", crate::VERSION_BUILD_REV);
     let root_paths = Roots::from_project(&project).paths();
     let OutputPaths { shell_gc_root } = &root_paths;
     if root_paths.all_exist() {
-        info!("gc roots exist"; "shell_gc_root" => ?shell_gc_root.as_os_str());
+        println!(
+            "gc roots exist, shell_gc_root: {:?}",
+            shell_gc_root.as_os_str()
+        );
     } else {
-        info!("gc roots do not exist"; "shell_gc_root" => ?shell_gc_root.as_os_str());
+        println!(
+            "gc roots do not exist, shell_gc_root: {:?}",
+            shell_gc_root.as_os_str()
+        );
     }
     ok()
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->

## Overview

The `info` command currently shows only information that is accessible via other means too. Let's make it more useful!

In this PR:
- every log line: remove "version" field
- every log line: change field name of the shell nix "root" to "expr"
- info command: keep printing lorri version
- info command: include information about GC roots

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/CONTRIBUTING.md for more on how to structure a pull request.
-->

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [ ] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

