### PR TITLE
human-panic: Include cause on Rust stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 [[package]]
 name = "human-panic"
 version = "1.0.1"
-source = "git+https://github.com/rust-cli/human-panic.git?rev=70db9489#70db948973a746418e3a23434fe48fe45d3c9866"
+source = "git+https://github.com/rust-cli/human-panic.git?rev=5195002d89b7f54cc68eb42255879654965bb175#5195002d89b7f54cc68eb42255879654965bb175"
 dependencies = [
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_type 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -437,7 +437,7 @@ dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "human-panic 1.0.1 (git+https://github.com/rust-cli/human-panic.git?rev=70db9489)",
+ "human-panic 1.0.1 (git+https://github.com/rust-cli/human-panic.git?rev=5195002d89b7f54cc68eb42255879654965bb175)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "md5 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1339,7 +1339,7 @@ dependencies = [
 "checksum getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-"checksum human-panic 1.0.1 (git+https://github.com/rust-cli/human-panic.git?rev=70db9489)" = "<none>"
+"checksum human-panic 1.0.1 (git+https://github.com/rust-cli/human-panic.git?rev=5195002d89b7f54cc68eb42255879654965bb175)" = "<none>"
 "checksum inotify 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24e40d6fd5d64e2082e0c796495c8ef5ad667a96d03e5aaa0becfd9d47bcbfb8"
 "checksum inotify-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -16,8 +16,8 @@ rec {
       edition = "2018";
       src = fetchgit {
          url = "https://github.com/rust-cli/human-panic.git";
-         rev = "70db948973a746418e3a23434fe48fe45d3c9866";
-         sha256 = "0yznxvgxl5nka75p4bh1pf8ab0c3mfqwihp7lcl0vbiv2yli7nkv";
+         rev = "5195002d89b7f54cc68eb42255879654965bb175";
+         sha256 = "1zs4ckhlczr9jgwagyw3bjmgvzsk1anm3hwd3m7j7hik0kypmpsq";
          fetchSubmodules = false;
       };
       dependencies = mapFeatures features ([

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ vec1 = "1.1.0"
 
 # pinned to a git commit pending v2.0 release
 # see: https://github.com/rust-cli/human-panic/issues/46
-human-panic = { git = "https://github.com/rust-cli/human-panic.git", rev = "70db9489" }
+human-panic = { git = "https://github.com/rust-cli/human-panic.git", rev = "5195002d89b7f54cc68eb42255879654965bb175" }
 
 [build-dependencies]
 varlink_generator = "9.0.0"


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->
Fixes https://github.com/target/lorri/issues/216.

## Overview

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/CONTRIBUTING.md for more on how to structure a pull request.
-->

Bumps `human-panic` to a version including this fix: https://github.com/rust-cli/human-panic/pull/66.

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [ ] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

