### PR TITLE
lorri shell

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -6,6 +6,12 @@
     # Find the current version number with `git log --pretty=%h | wc -l`
     entries = [
       {
+        version = 429;
+        changes = ''
+          - Re-introduced `lorri shell` command.
+        '';
+      }
+      {
         version = 309;
         changes = ''
           - The deprecated `lorri shell` command was removed.

--- a/release.nix
+++ b/release.nix
@@ -6,12 +6,6 @@
     # Find the current version number with `git log --pretty=%h | wc -l`
     entries = [
       {
-        version = 429;
-        changes = ''
-          - Re-introduced `lorri shell` command.
-        '';
-      }
-      {
         version = 309;
         changes = ''
           - The deprecated `lorri shell` command was removed.

--- a/shell.nix
+++ b/shell.nix
@@ -40,7 +40,6 @@ let
     pkgs.cargo
     pkgs.rustc
     pkgs.rustfmt
-    pkgs.bashInteractive
     pkgs.git
     pkgs.direnv
     pkgs.shellcheck
@@ -91,11 +90,6 @@ pkgs.mkShell (
       # see https://github.com/direnv/direnv/issues/427
       exec 3>&1 # store stdout (1) in fd 3
       exec 1>&2 # make stdout (1) an alias for stderr (2)
-
-      # this is needed so `lorri shell` runs the proper shell from
-      # inside this project's nix-shell. If you run `lorri` within a
-      # nix-shell, you don't need this.
-      export SHELL="${pkgs.bashInteractive}/bin/bash";
 
       alias ci="ci_check"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,10 @@ pub enum Command {
     #[structopt(name = "info", alias = "information")]
     Info(InfoOptions),
 
+    /// Open a new shell
+    #[structopt(name = "shell")]
+    Shell(ShellOptions),
+
     /// Build `shell.nix` whenever an input file changes
     #[structopt(name = "watch")]
     Watch(WatchOptions),
@@ -50,7 +54,7 @@ pub enum Command {
     Init,
 }
 
-/// Options for `watch` subcommand.
+/// Options for the `direnv` subcommand.
 #[derive(StructOpt, Debug)]
 pub struct DirenvOptions {
     /// The .nix file in the current directory to use
@@ -58,7 +62,7 @@ pub struct DirenvOptions {
     pub nix_file: PathBuf,
 }
 
-/// Options for `watch` subcommand.
+/// Options for the `info` subcommand.
 #[derive(StructOpt, Debug)]
 pub struct InfoOptions {
     /// The .nix file in the current directory to use
@@ -69,7 +73,15 @@ pub struct InfoOptions {
     pub nix_file: PathBuf,
 }
 
-/// Options for `watch` subcommand.
+/// Options for the `shell` subcommand.
+#[derive(StructOpt, Debug)]
+pub struct ShellOptions {
+    /// The .nix file in the current directory to use
+    #[structopt(long = "shell-file", parse(from_os_str), default_value = "shell.nix")]
+    pub nix_file: PathBuf,
+}
+
+/// Options for the `watch` subcommand.
 #[derive(StructOpt, Debug)]
 pub struct WatchOptions {
     /// The .nix file in the current directory to use

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use lorri::constants;
 use lorri::locate_file;
 use lorri::logging;
 use lorri::ops::error::{ExitError, OpResult};
-use lorri::ops::{daemon, direnv, info, init, ping, upgrade, watch};
+use lorri::ops::{daemon, direnv, info, init, ping, shell, upgrade, watch};
 use lorri::project::Project;
 use lorri::NixFile;
 use slog::{debug, error, o};
@@ -89,6 +89,10 @@ fn run_command(log: slog::Logger, opts: Arguments) -> OpResult {
         Command::Direnv(opts) => {
             let (project, _guard) = with_project(&opts.nix_file)?;
             direnv::main(project, /* shell_output */ std::io::stdout())
+        }
+        Command::Shell(opts) => {
+            let (project, _guard) = with_project(&opts.nix_file)?;
+            shell::main(project)
         }
         Command::Watch(opts) => {
             let (project, _guard) = with_project(&opts.nix_file)?;

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -5,6 +5,7 @@ pub mod direnv;
 pub mod info;
 pub mod init;
 pub mod ping;
+pub mod shell;
 pub mod upgrade;
 pub mod watch;
 

--- a/src/ops/shell.rs
+++ b/src/ops/shell.rs
@@ -1,0 +1,87 @@
+//! Open up a project shell
+
+use crate::builder;
+use crate::builder::RunStatus;
+use crate::nix::CallOpts;
+use crate::ops::error::{ExitError, OpResult};
+use crate::project::{roots::Roots, Project};
+use crossbeam_channel as chan;
+use slog_scope::debug;
+use std::io;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+use std::{env, fs, thread};
+
+/// See the documentation for lorri::cli::Command::Shell for more
+/// details.
+pub fn main(project: Project) -> OpResult {
+    let shell = env::var("SHELL").expect("lorri shell requires $SHELL to be set");
+    debug!("using shell path {}", shell);
+
+    let tempdir = tempfile::tempdir().expect("failed to create temporary directory");
+    let mut bash_cmd = bash_cmd(project, tempdir.path())?;
+    debug!("bash"; "command" => ?bash_cmd);
+    bash_cmd
+        .args(&["-c", &format!("exec {}", shell)])
+        .status()
+        .expect("failed to execute bash");
+    Ok(())
+}
+
+/// Instantiates a `Command` to start bash.
+pub fn bash_cmd(project: Project, tempdir: &Path) -> Result<Command, ExitError> {
+    let (tx, rx) = chan::unbounded();
+    thread::spawn(move || {
+        eprint!("lorri: building environment");
+        let mut last = Instant::now();
+        for msg in rx {
+            // Set the maximum rate of the "progress bar"
+            if last.elapsed() >= Duration::from_millis(500) {
+                eprint!(".");
+                io::stderr().flush().unwrap();
+                last = Instant::now();
+            }
+            debug!("build"; "message" => ?msg);
+        }
+        eprintln!(". done");
+    });
+
+    let run_result = builder::run(tx, &project.nix_file, &project.cas)
+        .map_err(|e| ExitError::temporary(format!("build failed: {:?}", e)))?;
+    let build = match run_result.status {
+        RunStatus::Complete(build) => Roots::from_project(&project)
+            .create_roots(build)
+            .map_err(|e| ExitError::temporary(format!("rooting the environment failed: {:?}", e))),
+        e => Err(ExitError::temporary(format!("build failed: {:?}", e))),
+    }?;
+
+    let init_file = tempdir.join("init");
+    fs::write(
+        &init_file,
+        format!(
+            r#"
+EVALUATION_ROOT="{}"
+
+{}"#,
+            build.shell_gc_root,
+            include_str!("direnv/envrc.bash")
+        ),
+    )
+    .expect("failed to write shell output");
+
+    debug!("building bash via runtime closure"; "closure" => crate::RUN_TIME_CLOSURE);
+    let bash_path = CallOpts::expression(&format!("(import {}).path", crate::RUN_TIME_CLOSURE))
+        .value::<PathBuf>()
+        .expect("failed to get runtime closure path");
+
+    let mut cmd = Command::new(bash_path.join("bash"));
+    cmd.env(
+        "BASH_ENV",
+        init_file
+            .to_str()
+            .expect("script file path not UTF-8 clean"),
+    );
+    Ok(cmd)
+}

--- a/tests/shell/loads_env/shell.nix
+++ b/tests/shell/loads_env/shell.nix
@@ -1,0 +1,6 @@
+with import ../../../nix/bogus-nixpkgs {};
+mkShell {
+  env = {
+    MY_ENV_VAR = "my_env_value";
+  };
+}

--- a/tests/shell/main.rs
+++ b/tests/shell/main.rs
@@ -1,0 +1,34 @@
+use lorri::{cas::ContentAddressable, ops::shell, project::Project, NixFile};
+use std::fs;
+use std::iter::FromIterator;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn loads_env() {
+    let tempdir = tempfile::tempdir().expect("tempfile::tempdir() failed us!");
+    let project = project("loads_env", tempdir.path());
+    let output = shell::bash_cmd(project, tempdir.path())
+        .unwrap()
+        .args(&["-c", "echo $MY_ENV_VAR"])
+        .output()
+        .expect("failed to run shell");
+
+    assert_eq!(
+        // The string conversion means we get a nice assertion failure message in case stdout does
+        // not match what we expected.
+        String::from_utf8(output.stdout).expect("stdout not UTF-8 clean"),
+        "my_env_value\n"
+    );
+}
+
+fn project(name: &str, cache_dir: &Path) -> Project {
+    let test_root = PathBuf::from_iter(&[env!("CARGO_MANIFEST_DIR"), "tests", "shell", name]);
+    let cas_dir = cache_dir.join("cas").to_owned();
+    fs::create_dir_all(&cas_dir).expect("failed to create CAS directory");
+    Project::new(
+        NixFile::Shell(test_root.join("shell.nix")),
+        &cache_dir.join("gc_roots").to_owned(),
+        ContentAddressable::new(cas_dir).unwrap(),
+    )
+    .unwrap()
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->

## Overview

Resurrects `lorri shell`. The idea is to make it as easy as possible for people with existing projects with `shell.nix` files to get started with lorri. The pitch is "just use `lorri shell` instead of `nix-shell`".

This version of `lorri shell` does not cache build results and does not attempt to launch from the cache. That will be done in a follow-up PR.

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/CONTRIBUTING.md for more on how to structure a pull request.
-->

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [x] Updated the documentation (code documentation, command help, ...)
- [x] Tested the change (unit or integration tests)
- [x] Amended the changelog in `release.nix` (see `release.nix` for instructions)

