### PR TITLE
lorri shell: set PS1 in bash

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,10 @@ pub enum Command {
     #[structopt(name = "shell")]
     Shell(ShellOptions),
 
+    /// (plumbing) Internal command used to launch user shell
+    #[structopt(name = "start_user_shell_")]
+    StartUserShell_(StartUserShellOptions_),
+
     /// Build `shell.nix` whenever an input file changes
     #[structopt(name = "watch")]
     Watch(WatchOptions),
@@ -78,6 +82,17 @@ pub struct InfoOptions {
 pub struct ShellOptions {
     /// The .nix file in the current directory to use
     #[structopt(long = "shell-file", parse(from_os_str), default_value = "shell.nix")]
+    pub nix_file: PathBuf,
+}
+
+/// Options for the `start_user_shell_` subcommand.
+#[derive(StructOpt, Debug)]
+pub struct StartUserShellOptions_ {
+    /// The path of the parent shell's binary
+    #[structopt(long = "shell-path", parse(from_os_str))]
+    pub shell_path: PathBuf,
+    /// The .nix file in the current directory to use to instantiate the project
+    #[structopt(long = "shell-file", parse(from_os_str))]
     pub nix_file: PathBuf,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use lorri::constants;
 use lorri::locate_file;
 use lorri::logging;
 use lorri::ops::error::{ExitError, OpResult};
-use lorri::ops::{daemon, direnv, info, init, ping, shell, upgrade, watch};
+use lorri::ops::{daemon, direnv, info, init, ping, shell, start_user_shell, upgrade, watch};
 use lorri::project::Project;
 use lorri::NixFile;
 use slog::{debug, error, o};
@@ -93,6 +93,10 @@ fn run_command(log: slog::Logger, opts: Arguments) -> OpResult {
         Command::Shell(opts) => {
             let (project, _guard) = with_project(&opts.nix_file)?;
             shell::main(project)
+        }
+        Command::StartUserShell_(opts) => {
+            let (project, _guard) = with_project(&opts.nix_file)?;
+            start_user_shell::main(project, opts)
         }
         Command::Watch(opts) => {
             let (project, _guard) = with_project(&opts.nix_file)?;

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -6,6 +6,7 @@ pub mod info;
 pub mod init;
 pub mod ping;
 pub mod shell;
+pub mod start_user_shell;
 pub mod upgrade;
 pub mod watch;
 

--- a/src/ops/start_user_shell.rs
+++ b/src/ops/start_user_shell.rs
@@ -1,0 +1,53 @@
+//! Helper command to create a user shell
+
+use crate::cas::ContentAddressable;
+use crate::cli::StartUserShellOptions_;
+use crate::ops::error::OpResult;
+use crate::project::Project;
+use std::os::unix::process::CommandExt;
+use std::path::Path;
+use std::process::Command;
+
+/// See the documentation for `crate::ops::shell::main`.
+pub fn main(project: Project, opts: StartUserShellOptions_) -> OpResult {
+    let e = shell_cmd(opts.shell_path.as_ref(), &project.cas).exec();
+
+    // 'exec' will never return on success, so if we get here, we know something has gone wrong.
+    panic!("failed to exec into '{}': {}", opts.shell_path.display(), e);
+}
+
+fn shell_cmd(shell_path: &Path, cas: &ContentAddressable) -> Command {
+    let mut cmd = Command::new(shell_path);
+
+    #[allow(clippy::single_match)] // only bash is currently handled
+    match shell_path
+        .file_name()
+        .expect("shell path must point to a file")
+        .to_str()
+        .expect("shell path is not UTF-8 clean")
+    {
+        "bash" => {
+            // In order to be able to override the prompt, we need to set PS1 *after* all other
+            // setup scripts have run. That makes it necessary to create our own setup script to be
+            // passed via --rcfile, which first sources all other setup scripts and then sets PS1.
+            let rcfile = cas
+                .file_from_string(
+                    // Using --rcfile disables sourcing of default setup scripts, so we source them
+                    // explicitly here.
+                    r#"
+[ -e /etc/bash.bashrc ] && . /etc/bash.bashrc
+[ -e ~/.bashrc ] && . ~/.bashrc
+PS1="(lorri) $PS1"
+"#,
+                )
+                .expect("failed to write bash init script");
+            cmd.args(&[
+                "--rcfile",
+                rcfile.to_str().expect("file path not UTF-8 clean"),
+            ]);
+        }
+        // TODO: add handling for other supported shells here.
+        _ => {}
+    }
+    cmd
+}

--- a/tests/shell/main.rs
+++ b/tests/shell/main.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 fn loads_env() {
     let tempdir = tempfile::tempdir().expect("tempfile::tempdir() failed us!");
     let project = project("loads_env", tempdir.path());
-    let output = shell::bash_cmd(project, tempdir.path())
+    let output = shell::bash_cmd(&project, tempdir.path())
         .unwrap()
         .args(&["-c", "echo $MY_ENV_VAR"])
         .output()


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->
Addresses part 2 of https://github.com/target/lorri/issues/297.

## Overview

Prepends `(lorri) ` to the PS1 if the user uses bash as their shell.

```console
[leo@daphnis project]$ basename $SHELL
bash
[leo@daphnis project]$ lorri shell
lorri: building environment...... done
(lorri) [leo@daphnis project]$
```

The PR also introduces the structure required to perform customisations for other shells.

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/CONTRIBUTING.md for more on how to structure a pull request.
-->

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [x] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

