### PR TITLE
Remove bincode dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,16 +97,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,7 +424,6 @@ name = "lorri"
 version = "0.1.0"
 dependencies = [
  "atomicwrites 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-panic 1.0.1 (git+https://github.com/rust-cli/human-panic.git?rev=5195002d89b7f54cc68eb42255879654965bb175)",
@@ -1307,7 +1296,6 @@ dependencies = [
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
 "checksum bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80"
 "checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -65,7 +65,6 @@ rec {
       src = exclude [ ".git" "target" ] ./.;
       dependencies = mapFeatures features ([
         (cratesIO.crates."atomicwrites"."${deps."lorri"."0.1.0"."atomicwrites"}" deps)
-        (cratesIO.crates."bincode"."${deps."lorri"."0.1.0"."bincode"}" deps)
         (cratesIO.crates."crossbeam_channel"."${deps."lorri"."0.1.0"."crossbeam_channel"}" deps)
         (cratesIO.crates."directories"."${deps."lorri"."0.1.0"."directories"}" deps)
         (crates."human_panic"."${deps."lorri"."0.1.0"."human_panic"}" deps)
@@ -94,7 +93,6 @@ rec {
     };
     features_.lorri."0.1.0" = deps: f: updateFeatures f (rec {
       atomicwrites."${deps.lorri."0.1.0".atomicwrites}".default = true;
-      bincode."${deps.lorri."0.1.0".bincode}".default = true;
       crossbeam_channel."${deps.lorri."0.1.0".crossbeam_channel}".default = true;
       directories."${deps.lorri."0.1.0".directories}".default = true;
       human_panic."${deps.lorri."0.1.0".human_panic}".default = true;
@@ -119,7 +117,6 @@ rec {
       vec1."${deps.lorri."0.1.0".vec1}".default = true;
     }) [
       (cratesIO.features_.atomicwrites."${deps."lorri"."0.1.0"."atomicwrites"}" deps)
-      (cratesIO.features_.bincode."${deps."lorri"."0.1.0"."bincode"}" deps)
       (cratesIO.features_.crossbeam_channel."${deps."lorri"."0.1.0"."crossbeam_channel"}" deps)
       (cratesIO.features_.directories."${deps."lorri"."0.1.0"."directories"}" deps)
       (features_.human_panic."${deps."lorri"."0.1.0"."human_panic"}" deps)
@@ -185,11 +182,6 @@ rec {
   };
   deps.base64."0.10.1" = {
     byteorder = "1.3.2";
-  };
-  deps.bincode."1.2.0" = {
-    byteorder = "1.3.2";
-    serde = "1.0.103";
-    autocfg = "0.1.7";
   };
   deps.bit_set."0.5.1" = {
     bit_vec = "0.5.1";
@@ -325,7 +317,6 @@ rec {
   };
   deps.lorri."0.1.0" = {
     atomicwrites = "0.2.5";
-    bincode = "1.2.0";
     crossbeam_channel = "0.3.9";
     directories = "1.0.2";
     human_panic = "1.0.1";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 
 [dependencies]
 atomicwrites = "0.2.3"
-bincode = "1.1.3"
 crossbeam-channel = "0.3.8"
 directories = "1.0.2"
 lazy_static = "1.2.0"

--- a/nix/carnix/crates-io.nix
+++ b/nix/carnix/crates-io.nix
@@ -433,38 +433,6 @@ rec {
 
 
 # end
-# bincode-1.2.0
-
-  crates.bincode."1.2.0" = deps: { features?(features_.bincode."1.2.0" deps {}) }: buildRustCrate {
-    crateName = "bincode";
-    version = "1.2.0";
-    description = "A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!";
-    authors = [ "Ty Overby <ty@pre-alpha.com>" "Francesco Mazzoli <f@mazzo.li>" "David Tolnay <dtolnay@gmail.com>" "Daniel Griffen" ];
-    sha256 = "0sfk6drrivn6xij8w6krskhn7fa5bq2jjvlvl7ipnsvjz3l1l949";
-    build = "build.rs";
-    dependencies = mapFeatures features ([
-      (crates."byteorder"."${deps."bincode"."1.2.0"."byteorder"}" deps)
-      (crates."serde"."${deps."bincode"."1.2.0"."serde"}" deps)
-    ]);
-
-    buildDependencies = mapFeatures features ([
-      (crates."autocfg"."${deps."bincode"."1.2.0"."autocfg"}" deps)
-    ]);
-    features = mkFeatures (features."bincode"."1.2.0" or {});
-  };
-  features_.bincode."1.2.0" = deps: f: updateFeatures f (rec {
-    autocfg."${deps.bincode."1.2.0".autocfg}".default = true;
-    bincode."1.2.0".default = (f.bincode."1.2.0".default or true);
-    byteorder."${deps.bincode."1.2.0".byteorder}".default = true;
-    serde."${deps.bincode."1.2.0".serde}".default = true;
-  }) [
-    (features_.byteorder."${deps."bincode"."1.2.0"."byteorder"}" deps)
-    (features_.serde."${deps."bincode"."1.2.0"."serde"}" deps)
-    (features_.autocfg."${deps."bincode"."1.2.0"."autocfg"}" deps)
-  ];
-
-
-# end
 # bit-set-0.5.1
 
   crates.bit_set."0.5.1" = deps: { features?(features_.bit_set."0.5.1" deps {}) }: buildRustCrate {


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->

## Overview

We don't use `bincode` anymore.

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/CONTRIBUTING.md for more on how to structure a pull request.
-->

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [ ] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

