### PR TITLE
Include commands in error messages where possible

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -91,7 +91,7 @@ fn instrumented_instantiation(
     debug!("nix-instantiate"; "command" => ?cmd);
 
     let mut child = cmd.spawn().map_err(|e| match e.kind() {
-        std::io::ErrorKind::NotFound => BuildError::spawn(e),
+        std::io::ErrorKind::NotFound => BuildError::spawn(&cmd, e),
         _ => BuildError::io(e),
     })?;
 
@@ -160,7 +160,7 @@ fn instrumented_instantiation(
             });
 
     if !exec_result.success() {
-        return Err(BuildError::exit(exec_result, log_lines));
+        return Err(BuildError::exit(&cmd, exec_result, log_lines));
     }
 
     assert!(
@@ -394,7 +394,7 @@ in {}
             &format!("dep = {};", drv("dep", r##"args = [ "-c" "exit 1" ];"##)),
         ))?);
 
-        if let Err(BuildError::Exit(..)) = run(&d, &cas) {
+        if let Err(BuildError::Exit { .. }) = run(&d, &cas) {
         } else {
             assert!(
                 false,

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,32 +3,52 @@
 use std::ffi::OsString;
 use std::fmt;
 use std::io::Error as IoError;
-use std::process::ExitStatus;
+use std::process::{Command, ExitStatus};
 
 /// An error that can occur during a build.
 #[derive(Clone, Debug)]
 pub enum BuildError {
     /// A system-level IO error occurred during the build.
-    // The underlying error is stored as a string because we need `BuildError` to implement `Copy`,
-    // but `io::Error` does not implement `Copy`.
-    Io(String),
+    Io {
+        /// Error message of the underlying error. Stored as a string because we need `BuildError`
+        /// to implement `Copy`, but `io::Error` does not implement `Copy`.
+        msg: String,
+    },
 
     /// An error occurred while spawning a Nix process.
     ///
     /// Usually this means that the relevant Nix executable was not on the $PATH.
-    // The underlying error is stored as a string because we need `BuildError` to implement `Copy`,
-    // but `io::Error` does not implement `Copy`.
-    Spawn(String),
+    Spawn {
+        /// The command that failed. Stored as a string because we need `BuildError` to implement
+        /// `Copy`, but `Command` does not implement `Copy`.
+        cmd: String,
+
+        /// Error message of the underlying error. Stored as a string because we need `BuildError`
+        /// to implement `Copy`, but `io::Error` does not implement `Copy`.
+        msg: String,
+    },
 
     /// The Nix process returned with a non-zero exit code.
-    ///
-    /// The `ExitStatus` is guaranteed to be not successful.
-    Exit(ExitStatus, Vec<OsString>),
+    Exit {
+        /// The command that failed. Stored as a string because we need `BuildError` to implement
+        /// `Copy`, but `Command` does not implement `Copy`.
+        cmd: String,
+
+        /// The `ExitStatus` of the command. The smart constructor `BuildError::exit` asserts that
+        /// it is non-successful.
+        status: ExitStatus,
+
+        /// Error logs of the failed process.
+        logs: Vec<OsString>,
+    },
 
     /// There was something wrong with the output of the Nix command.
     ///
     /// This error may for example indicate that the wrong number of outputs was produced.
-    Output(String),
+    Output {
+        /// Error message explaining the nature of the output error.
+        msg: String,
+    },
 }
 
 impl From<IoError> for BuildError {
@@ -52,24 +72,29 @@ impl From<serde_json::Error> for BuildError {
 impl fmt::Display for BuildError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            BuildError::Io(e) => write!(f, "I/O error: {}", e),
-            BuildError::Spawn(e) => write!(
+            BuildError::Io { msg } => write!(f, "I/O error: {}", msg),
+            BuildError::Spawn { cmd, msg } => write!(
                 f,
-                "failed to spawn Nix process: {}. Is Nix installed and on the $PATH?",
-                e
+                "failed to spawn Nix process. Is Nix installed and on the $PATH?\n\
+                 $ {}\n\
+                 {}",
+                cmd, msg,
             ),
-            BuildError::Exit(status, logs) => write!(
+            BuildError::Exit { cmd, status, logs } => write!(
                 f,
-                "Nix process returned with exit code {}. Error logs:\n{}",
+                "Nix process returned exit code {}.\n\
+                 $ {}\n\
+                 {}",
                 status
                     .code()
                     .map_or("<unknown>".to_string(), |c| i32::to_string(&c)),
+                cmd,
                 logs.iter()
                     .map(|l| l.to_string_lossy())
                     .collect::<Vec<_>>()
                     .join("\n")
             ),
-            BuildError::Output(msg) => write!(f, "{}", msg),
+            BuildError::Output { msg } => write!(f, "{}", msg),
         }
     }
 }
@@ -80,38 +105,47 @@ impl BuildError {
     where
         D: fmt::Display,
     {
-        BuildError::Io(format!("{}", e))
+        BuildError::Io {
+            msg: format!("{}", e),
+        }
     }
 
     /// Smart constructor for `BuildError::Spawn`
-    pub fn spawn<D>(e: D) -> BuildError
+    pub fn spawn<D>(cmd: &Command, e: D) -> BuildError
     where
         D: fmt::Display,
     {
-        BuildError::Spawn(format!("{}", e))
+        BuildError::Spawn {
+            cmd: format!("{:?}", cmd),
+            msg: format!("{}", e),
+        }
     }
 
     /// Smart constructor for `BuildError::Exit`
-    pub fn exit(status: ExitStatus, logs: Vec<OsString>) -> BuildError {
+    pub fn exit(cmd: &Command, status: ExitStatus, logs: Vec<OsString>) -> BuildError {
         assert!(
             !status.success(),
             "cannot create an exit error from a successful status code"
         );
-        BuildError::Exit(status, logs)
+        BuildError::Exit {
+            cmd: format!("{:?}", cmd),
+            status,
+            logs,
+        }
     }
 
     /// Smart constructor for `BuildError::Output`
     pub fn output(msg: String) -> BuildError {
-        BuildError::Output(msg)
+        BuildError::Output { msg }
     }
 
     /// Is there something the user can do about this error?
     pub fn is_actionable(&self) -> bool {
         match self {
-            BuildError::Io(_) => false,
-            BuildError::Spawn(_) => true,   // install Nix or fix $PATH
-            BuildError::Exit(_, _) => true, // fix Nix expression
-            BuildError::Output(_) => true,  // fix Nix expression
+            BuildError::Io { .. } => false,
+            BuildError::Spawn { .. } => true, // install Nix or fix $PATH
+            BuildError::Exit { .. } => true,  // fix Nix expression
+            BuildError::Output { .. } => true, // fix Nix expression
         }
     }
 }

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -257,7 +257,7 @@ impl<'a> CallOpts<'a> {
     ///         .path();
     ///
     /// match paths {
-    ///    Err(BuildError::Output(_)) => {},
+    ///    Err(BuildError::Output { .. }) => {},
     ///    otherwise => panic!(otherwise)
     /// }
     /// ```
@@ -267,7 +267,7 @@ impl<'a> CallOpts<'a> {
 
         match (paths.pop(), paths.pop()) {
             // Exactly zero
-            (None, _) => Err(BuildError::Output(
+            (None, _) => Err(BuildError::output(
                 "expected exactly one build output, got zero".to_string(),
             )),
 
@@ -275,7 +275,7 @@ impl<'a> CallOpts<'a> {
             (Some(path), None) => Ok((path, gc_root)),
 
             // More than one
-            (Some(_), Some(_)) => Err(BuildError::Output(
+            (Some(_), Some(_)) => Err(BuildError::output(
                 "expected exactly one build output, got more".to_string(),
             )),
         }
@@ -353,7 +353,7 @@ impl<'a> CallOpts<'a> {
 
         // 0. spawn the process
         let mut nix_proc = cmd.spawn().map_err(|e| match e.kind() {
-            std::io::ErrorKind::NotFound => BuildError::spawn(e),
+            std::io::ErrorKind::NotFound => BuildError::spawn(&cmd, e),
             _ => BuildError::io(e),
         })?;
 
@@ -388,6 +388,7 @@ impl<'a> CallOpts<'a> {
 
         if !nix_proc_result.success() {
             Err(BuildError::exit(
+                &cmd,
                 nix_proc_result,
                 stderr_rx.iter().collect::<Vec<_>>(),
             ))


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->
Follow-up to https://github.com/target/lorri/pull/296.

## Overview

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/CONTRIBUTING.md for more on how to structure a pull request.
-->

- Include commands in error messages if possible. This helps with debugging.
- `BuildError` variants are now represented as structs with per-field documentation.

Example (when combined with #303):

<pre>lorri: building environment.. done
Jan 28 16:20:23.397 <font color="#CC0000">ERRO</font> <b>Build failed. No cached environment available.</b>
<b>Build error: Nix process returned exit code 1.</b>
<b>$ &quot;nix-instantiate&quot; &quot;-vv&quot; &quot;--add-root&quot; &quot;/tmp/.tmpzX7Qhq/result&quot; &quot;--indirect&quot; &quot;--argstr&quot; &quot;runtimeClosure&quot; &quot;/nix/store/ymb5ivx2yadbaflw38985xy156059kdy-runtime-closure.nix&quot; &quot;--argstr&quot; &quot;shellSrc&quot; &quot;/home/leo/Code/shell.nix&quot; &quot;--&quot; &quot;/home/leo/.cache/lorri/cas/66c4fc8f70f0926419733bdbfd442181&quot;</b>
<b>error: undefined variable &apos;x&apos; at /home/leo/Code/shell.nix:2:1</b>
</pre>

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [x] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

