### PR TITLE
lorri shell: set PS1 if user shell is zsh

### DIFF
--- a/src/ops/start_user_shell.rs
+++ b/src/ops/start_user_shell.rs
@@ -7,19 +7,24 @@ use crate::project::Project;
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::Command;
+use std::{env, fs};
 
 /// See the documentation for `crate::ops::shell::main`.
 pub fn main(project: Project, opts: StartUserShellOptions_) -> OpResult {
-    let e = shell_cmd(opts.shell_path.as_ref(), &project.cas).exec();
+    // This temporary directory will not be cleaned up by lorri because we exec into the shell
+    // process, which means that destructors will not be run. However, (1) the temporary files
+    // lorri creates in this directory are only a few hundred bytes long; (2) the directory will be
+    // cleaned up on reboot or whenever the OS decides to purge temporary directories.
+    let tempdir = tempfile::tempdir().expect("failed to create temporary directory");
+    let e = shell_cmd(opts.shell_path.as_ref(), &project.cas, tempdir.path()).exec();
 
     // 'exec' will never return on success, so if we get here, we know something has gone wrong.
     panic!("failed to exec into '{}': {}", opts.shell_path.display(), e);
 }
 
-fn shell_cmd(shell_path: &Path, cas: &ContentAddressable) -> Command {
+fn shell_cmd(shell_path: &Path, cas: &ContentAddressable, tempdir: &Path) -> Command {
     let mut cmd = Command::new(shell_path);
 
-    #[allow(clippy::single_match)] // only bash is currently handled
     match shell_path
         .file_name()
         .expect("shell path must point to a file")
@@ -27,9 +32,8 @@ fn shell_cmd(shell_path: &Path, cas: &ContentAddressable) -> Command {
         .expect("shell path is not UTF-8 clean")
     {
         "bash" => {
-            // In order to be able to override the prompt, we need to set PS1 *after* all other
-            // setup scripts have run. That makes it necessary to create our own setup script to be
-            // passed via --rcfile, which first sources all other setup scripts and then sets PS1.
+            // To override the prompt, we need to set PS1 *after* all other setup scripts have run.
+            // That makes it necessary to create our own setup script to be passed via --rcfile.
             let rcfile = cas
                 .file_from_string(
                     // Using --rcfile disables sourcing of default setup scripts, so we source them
@@ -46,7 +50,31 @@ PS1="(lorri) $PS1"
                 rcfile.to_str().expect("file path not UTF-8 clean"),
             ]);
         }
-        // TODO: add handling for other supported shells here.
+        "zsh" => {
+            // Zsh does not support anything like bash's --rcfile. However, zsh sources init
+            // scripts from $ZDOTDIR by default. So we set $ZDOTDIR to a directory under lorri's
+            // control, follow the default sourcing procedure, and then set the PS1.
+            fs::write(
+                tempdir.join(".zshrc"),
+                // See "STARTUP/SHUTDOWN FILES" section of the zshall man page as well as
+                // https://superuser.com/a/591440/318156.
+                r#"
+unset RCS # disable automatic sourcing of startup scripts
+test -f "$ZDOTDIR_OR_HOME/.zshenv" && . "$ZDOTDIR_OR_HOME/.zshenv"
+test -f "/etc/zshrc"               && . "/etc/zshrc"
+test -f "$ZDOTDIR_OR_HOME/.zshrc"  && . "$ZDOTDIR_OR_HOME/.zshrc"
+PS1="(lorri) $PS1"
+"#,
+            )
+            .expect("failed to write zsh init script");
+            cmd.env(
+                "ZDOTDIR_OR_HOME",
+                env::var("ZDOTDIR")
+                    .unwrap_or_else(|_| env::var("HOME").expect("$HOME must be set")),
+            );
+            cmd.env("ZDOTDIR", tempdir);
+        }
+        // Add handling for other supported shells here.
         _ => {}
     }
     cmd


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->

## Overview

Prepend `(lorri) ` to the user's PS1 if they use zsh.

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/CONTRIBUTING.md for more on how to structure a pull request.
-->

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [x] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

