### PR TITLE
Explain why lorri is not on crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,21 @@ times.
 
 [Webchat]: https://kiwiirc.com/nextclient/#irc://irc.freenode.net:+6697/#lorri
 
+### Why is lorri not on [crates.io][]?
+
+Command line tools written in Rust are commonly available as Rust crates on
+[crates.io][]. lorri is not distributed in this way, for good reasons.
+
+lorri can only be built within a Nix environment, and it can only be installed
+via Nix. This is because lorri specifies its runtime dependencies as a Nix
+closure, and because Nix is itself a runtime dependency of lorri.
+
+In addition to these technical reasons, there is simply no point in running
+lorri if you don't have Nix installed. And if you have Nix installed, then
+you're best off installing lorri via Nix.
+
+[crates.io]: https://crates.io
+
 ## How To Help
 
 All development on lorri happens on the Github repository, in the


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->
Relates to https://github.com/target/lorri/issues/269.

## [Preview](https://github.com/curiousleo/lorri/tree/no-crates-io#why-is-lorri-not-on-cratesio)

Users might reasonably expect that lorri, being a Rust command line tool, can be obtained from https://crates.io. It cannot, for good reasons, which we should spell out.

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/CONTRIBUTING.md for more on how to structure a pull request.
-->

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [x] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

