### PR TITLE
Pin nixos-19.09 instead of nixos-unstable

### DIFF
--- a/nix/nixpkgs-fmt.nix
+++ b/nix/nixpkgs-fmt.nix
@@ -1,0 +1,22 @@
+# https://github.com/NixOS/nixpkgs/blob/85142b9ad27b5caf614cb99e728e7b67a7bfe481/pkgs/tools/nix/nixpkgs-fmt/default.nix
+{ lib, rustPlatform, fetchFromGitHub }:
+rustPlatform.buildRustPackage rec {
+  pname = "nixpkgs-fmt";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1iylldgyvrcarfigpbhicg6j6qyipfiqn7gybza7qajfzyprjqfa";
+  };
+
+  cargoSha256 = "04my7dlp76dxs1ydy2sbbca8sp3n62wzdxyc4afcmrg8anb0ghaf";
+
+  meta = with lib; {
+    description = "Nix code formatter for nixpkgs";
+    homepage = "https://nix-community.github.io/nixpkgs-fmt";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ zimbatm ];
+  };
+}

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/nixos/nixpkgs-channels.git",
-  "rev": "3140fa89c51233397f496f49014f6b23216667c2",
-  "date": "2019-12-05T01:28:43+01:00",
-  "sha256": "18p0d5lnfvzsyfah02mf6bi249990pfwnylwhqdh8qi70ncrk3f8",
+  "rev": "6d9a4a615ee2706047c2cec3acc61d2cfbffdb0b",
+  "date": "2020-01-28T14:21:49+01:00",
+  "sha256": "1zgwp31nqh7glh7l2i0n5vic5jv1683l6lvc7r7wdmkbsbkmig1p",
   "fetchSubmodules": false
 }

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -4,5 +4,11 @@ let
     url = "https://github.com/NixOS/nixpkgs/archive/${srcDef.rev}.tar.gz";
     sha256 = srcDef.sha256;
   };
+  # The version of nixpkgs-fmt in release-19.09 [1] does not support --check, which
+  # we need for CI. Hence this overlay.
+  # [1] https://github.com/NixOS/nixpkgs/blob/release-19.09/pkgs/tools/nix/nixpkgs-fmt/default.nix
+  nixpkgs-fmt-overlay = self: super: {
+    nixpkgs-fmt = self.callPackage ./nixpkgs-fmt.nix {};
+  };
 in
-import nixpkgs {}
+import nixpkgs { overlays = [ nixpkgs-fmt-overlay ]; }

--- a/nix/update-dependencies.sh
+++ b/nix/update-dependencies.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+# lorri should always build with the current NixOS stable branch.
+channel='nixos-19.09'
 nix-prefetch-git https://github.com/nixos/nixpkgs-channels.git \
-                 --rev refs/heads/nixos-unstable > ./nix/nixpkgs.json
+                 --rev "refs/heads/${channel}" > ./nix/nixpkgs.json
 

--- a/src/build_loop.rs
+++ b/src/build_loop.rs
@@ -95,9 +95,12 @@ impl<'a> BuildLoop<'a> {
                         output_paths = Some(result.output_paths.clone());
                         send(Event::Completed(result));
                     }
-                    Err(e) if e.is_actionable() => send(Event::Failure(e)),
                     Err(e) => {
-                        panic!("Unrecoverable error:\n{}", e);
+                        if e.is_actionable() {
+                            send(Event::Failure(e))
+                        } else {
+                            panic!("Unrecoverable error:\n{}", e)
+                        }
                     }
                 }
                 reason = None;

--- a/src/ops/watch.rs
+++ b/src/ops/watch.rs
@@ -27,8 +27,13 @@ fn main_run_once(project: Project) -> OpResult {
             print_build_message(msg);
             ok()
         }
-        Err(e) if e.is_actionable() => Err(ExitError::expected_error(format!("{:#?}", e))),
-        Err(e) => Err(ExitError::temporary(format!("{:?}", e))),
+        Err(e) => {
+            if e.is_actionable() {
+                Err(ExitError::expected_error(format!("{:#?}", e)))
+            } else {
+                Err(ExitError::temporary(format!("{:?}", e)))
+            }
+        }
     }
 }
 

--- a/tests/integration/envrctestcase.rs
+++ b/tests/integration/envrctestcase.rs
@@ -20,7 +20,10 @@ fn find_program<S: Display + AsRef<OsStr>>(program: S) -> PathBuf {
         .args(&["-c", "type -p \"$1\"", "--"])
         .arg(&program)
         .output()
-        .expect(&format!("Failed to execute «bash -c 'which {}'»", &program));
+        .expect(&format!(
+            "Failed to execute «bash -c 'which {}'»",
+            &program
+        ));
 
     assert!(
         output.status.success(),


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->
Relates to https://github.com/target/lorri/pull/314#issuecomment-580258799.

## Overview

If we want to support NixOS 19.09, we should pin a version of it rather than of `nixos-unstable`.

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/CONTRIBUTING.md for more on how to structure a pull request.
-->

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [ ] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

