### PR TITLE
Ci build on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+  - master
 git:
   depth: false
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 git:
   depth: false
-language: shell
-matrix:
+jobs:
   include:
   - before_cache:
     - rm -rvf "$TRAVIS_BUILD_DIR/target/debug/liblorri.rlib"
@@ -137,3 +136,4 @@ matrix:
         cachix push lorri-test < ./cachix-file
       fi
     - lorri self-upgrade local $(pwd)
+language: shell

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 git:
   depth: false
-language: minimal
+language: shell
 matrix:
   include:
   - before_cache:

--- a/.travis.yml.nix
+++ b/.travis.yml.nix
@@ -147,7 +147,7 @@ let
       {
         git.depth = false;
         language = "shell";
-        matrix.include = map mergeShallowConcatLists [
+        jobs.include = map mergeShallowConcatLists [
           # Verifying lints on macOS and Linux ensures nix-shell works
           # on both platforms.
           [ hosts.linux scripts.setup-cachix scripts.lints (scripts.cache "linux") ]

--- a/.travis.yml.nix
+++ b/.travis.yml.nix
@@ -147,6 +147,8 @@ let
       {
         git.depth = false;
         language = "shell";
+        # we build PRs and master
+        branches.only = [ "master" ];
         jobs.include = map mergeShallowConcatLists [
           # Verifying lints on macOS and Linux ensures nix-shell works
           # on both platforms.

--- a/.travis.yml.nix
+++ b/.travis.yml.nix
@@ -146,7 +146,7 @@ let
     in
       {
         git.depth = false;
-        language = "minimal";
+        language = "shell";
         matrix.include = map mergeShallowConcatLists [
           # Verifying lints on macOS and Linux ensures nix-shell works
           # on both platforms.


### PR DESCRIPTION
Fix a few CI linting errors and enable master builds.

I’m not 100% sure whether this disables PR builds, let’s see …