### PR TITLE
make nixpkgs overridable in the shell.nix template

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -6,6 +6,14 @@
     # Find the current version number with `git log --pretty=%h | wc -l`
     entries = [
       {
+        version = 510;
+        changes = ''
+          - The shell.nix template used by `lorri init` was changed to take
+            `pkgs` as an argument with import of `<nixpkgs>` used as the
+            default value.
+        '';
+      }
+      {
         version = 476;
         changes = ''
           Introduces internal subcommand `lorri internal__stream_events`

--- a/src/trivial-shell.nix
+++ b/src/trivial-shell.nix
@@ -1,6 +1,5 @@
-let
-  pkgs = import <nixpkgs> {};
-in
+{ pkgs ? import <nixpkgs> {} }:
+
 pkgs.mkShell {
   buildInputs = [
     pkgs.hello


### PR DESCRIPTION
## Overview

The default template is missing one useful feature that would allow users to evaluate their shells with modified packages set. The approach to fixing this is to update the default template to take `pkgs` attrset via a function argument.

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [ ] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

