### PR TITLE
fix(cli): display internal commands in a subcommand #343

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,8 +8,7 @@ non-negative integers without leading zeroes.
 ### Terminology
 
 lorri is a command line tool with multiple **subcommands**. Those subcommands
-are either _external_ or _internal_.  Internal subcommands' names start with
-"internal\_\_". There are _mandatory_ and _optional_ **command line options**,
+are either _external_ or _internal_. There are _mandatory_ and _optional_ **command line options**,
 which can be attached to the top-level command or to subcommands.
 
 Subcommands fall into two categories based on the intended consumer of their

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,8 +8,8 @@ non-negative integers without leading zeroes.
 ### Terminology
 
 lorri is a command line tool with multiple **subcommands**. Those subcommands
-are either _external_ or _internal_. There are _mandatory_ and _optional_ **command line options**,
-which can be attached to the top-level command or to subcommands.
+are either _external_ or _internal_. _internal_ subcommands are now all grouped in `lorri internal`.
+There are _mandatory_ and _optional_ **command line options**, which can be attached to the top-level command or to subcommands.
 
 Subcommands fall into two categories based on the intended consumer of their
 outputs: their **outputs** may be for _human consumption_ or

--- a/release.nix
+++ b/release.nix
@@ -6,6 +6,13 @@
     # Find the current version number with `git log --pretty=%h | wc -l`
     entries = [
       {
+        version = 518;
+        changes = ''
+          Internal subcommands is now visible for all users inside the internal
+          subcommand. Example `lorri internal stream_events` instead of `lorri internal__stream_events`.
+        '';
+      }
+      {
         version = 517;
         changes = ''
           - Fix issue with spaces in PATH entries

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,9 +6,7 @@
 // bit more typing, but the long name makes the intent much more obvious. The only short option
 // right now is `-v` for verbosity, and it should probably stay that way.
 //
-// Prefix internal commands with `internal__` and hide them from the auto-generated help using
-// `raw(setting = "structopt::clap::AppSettings::Hidden")`. See MAINTAINERS.md for details on
-// internal and non-internal commands.
+// See MAINTAINERS.md for details on internal and non-internal commands.
 
 use std::path::PathBuf;
 
@@ -43,13 +41,6 @@ pub enum Command {
     #[structopt(name = "shell")]
     Shell(ShellOptions),
 
-    /// (internal) Used internally by `lorri shell`
-    #[structopt(
-        name = "internal__start_user_shell",
-        raw(setting = "structopt::clap::AppSettings::Hidden")
-    )]
-    StartUserShell_(StartUserShellOptions_),
-
     /// Build project whenever an input file changes
     #[structopt(name = "watch")]
     Watch(WatchOptions),
@@ -58,20 +49,6 @@ pub enum Command {
     #[structopt(name = "daemon")]
     Daemon,
 
-    /// (internal) Tell the lorri daemon to care about the current directory's project
-    #[structopt(
-        name = "internal__ping",
-        raw(setting = "structopt::clap::AppSettings::Hidden")
-    )]
-    Ping_(Ping_),
-
-    /// (plumbing) Ask the lorri daemon to report build events as they occur
-    #[structopt(
-        name = "internal__stream_events",
-        raw(setting = "structopt::clap::AppSettings::Hidden")
-    )]
-    StreamEvents_(StreamEvents_),
-
     /// Upgrade Lorri
     #[structopt(name = "self-upgrade", alias = "self-update")]
     Upgrade(UpgradeTo),
@@ -79,6 +56,14 @@ pub enum Command {
     /// Write bootstrap files to current directory to create a new lorri project
     #[structopt(name = "init")]
     Init,
+
+    /// Internal commands, only use to experiment with unstable features
+    #[structopt(name = "internal")]
+    Internal {
+        /// Sub-command to execute
+        #[structopt(subcommand)]
+        command: Internal_,
+    },
 }
 
 /// Options for the `direnv` subcommand.
@@ -111,7 +96,7 @@ pub struct ShellOptions {
     pub cached: bool,
 }
 
-/// Options for the `internal__start_user_shell` subcommand.
+/// Options for the `internal start_user_shell` subcommand.
 #[derive(StructOpt, Debug)]
 pub struct StartUserShellOptions_ {
     /// The path of the parent shell's binary
@@ -131,6 +116,22 @@ pub struct WatchOptions {
     /// Exit after a the first build
     #[structopt(long = "once")]
     pub once: bool,
+}
+
+/// Sub-commands which lorri can execute for internal features
+#[derive(StructOpt, Debug)]
+pub enum Internal_ {
+    /// (internal) Used internally by `lorri shell`
+    #[structopt(name = "start_user_shell")]
+    StartUserShell_(StartUserShellOptions_),
+
+    /// (plumbing) Tell the lorri daemon to care about the current directory's project
+    #[structopt(name = "ping")]
+    Ping_(Ping_),
+
+    /// (plumbing) Ask the lorri daemon to report build events as they occur
+    #[structopt(name = "stream_events")]
+    StreamEvents_(StreamEvents_),
 }
 
 /// Send a message with a lorri project.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -32,7 +32,7 @@ impl From<Event> for LoopHandlerEvent {
 /// so the user editor would send this message when a file
 /// in the project is opened, through `lorri direnv` for example.
 ///
-/// `lorri internal__ping` is the internal command which triggers this signal.
+/// `lorri internal ping` is the internal command which triggers this signal.
 ///
 /// Note especially that we don’t want to fix the server reaction to
 /// this signal yet, sending `IndicateActivity` does not necessarily

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use lorri::cli::{Arguments, Command};
+use lorri::cli::{Arguments, Command, Internal_};
 use lorri::constants;
 use lorri::locate_file;
 use lorri::logging;
@@ -96,10 +96,7 @@ fn run_command(log: slog::Logger, opts: Arguments) -> OpResult {
             let (project, _guard) = with_project(&opts.nix_file)?;
             shell::main(project, opts)
         }
-        Command::StartUserShell_(opts) => {
-            let (project, _guard) = with_project(&opts.nix_file)?;
-            start_user_shell::main(project, opts)
-        }
+
         Command::Watch(opts) => {
             let (project, _guard) = with_project(&opts.nix_file)?;
             watch::main(project, opts)
@@ -112,21 +109,25 @@ fn run_command(log: slog::Logger, opts: Arguments) -> OpResult {
             let _guard = without_project();
             upgrade::main(opts, paths.cas_store())
         }
-        // TODO: remove
-        Command::Ping_(opts) => {
-            let _guard = without_project();
-            get_shell_nix(&opts.nix_file).and_then(ping::main)
-        }
-
-        Command::StreamEvents_(se) => {
-            let _guard = without_project();
-            stream_events::main(se.kind)
-        }
-
         Command::Init => {
             let _guard = without_project();
             init::main(TRIVIAL_SHELL_SRC, DEFAULT_ENVRC)
         }
+
+        Command::Internal { command } => match command {
+            Internal_::Ping_(opts) => {
+                let _guard = without_project();
+                get_shell_nix(&opts.nix_file).and_then(ping::main)
+            }
+            Internal_::StartUserShell_(opts) => {
+                let (project, _guard) = with_project(&opts.nix_file)?;
+                start_user_shell::main(project, opts)
+            }
+            Internal_::StreamEvents_(se) => {
+                let _guard = without_project();
+                stream_events::main(se.kind)
+            }
+        },
     }
 }
 

--- a/src/ops/shell.rs
+++ b/src/ops/shell.rs
@@ -29,7 +29,7 @@ use std::{env, thread};
 /// ├── builds the project environment if --cached is false
 /// ├── writes a bash init script that loads the project environment
 /// ├── SPAWNS bash with the init script as its `--rcfile`
-/// │   └── EXECS `lorri internal__start_user_shell`
+/// │   └── EXECS `lorri internal start_user_shell`
 /// │       ├── (*) performs shell-specific setup for $SHELL
 /// │       └── EXECS into user shell $SHELL
 /// │           └── interactive user shell
@@ -56,7 +56,7 @@ pub fn main(project: Project, opts: ShellOptions) -> OpResult {
     bash_cmd
         .args(&[
             "-c",
-            "exec \"$1\" internal__start_user_shell --shell-path=\"$2\" --shell-file=\"$3\"",
+            "exec \"$1\" internal start_user_shell --shell-path=\"$2\" --shell-file=\"$3\"",
             "--",
             &lorri
                 .to_str()

--- a/src/ops/shell.rs
+++ b/src/ops/shell.rs
@@ -70,7 +70,7 @@ pub fn main(project: Project, opts: ShellOptions) -> OpResult {
 
     if !status.success() {
         Err(ExitError::panic(format!(
-            "cannot run lorri shell: fail to execute internal shell command (error: {})",
+            "cannot run lorri shell: failed to execute internal shell command (error: {})",
             status
         )))
     } else {


### PR DESCRIPTION
## Overview

Put each internal commands in a subcommands visible for all users.
close #343 

BTW should I remove the ping command ? (related to the TODO comment in file)

## Checklist

- [X] Updated the documentation (code documentation, command help, ...)
- [x] Tested the change (unit or integration tests)
- [X] Amended the changelog in `release.nix` (see `release.nix` for instructions)

