### PR TITLE
Don't watch /nix/store files (they can't change)

### DIFF
--- a/src/watch.rs
+++ b/src/watch.rs
@@ -151,6 +151,10 @@ impl Watch {
     }
 
     fn add_path(&mut self, path: &PathBuf) -> Result<(), notify::Error> {
+        if path.canonicalize()?.starts_with(Path::new("/nix/store")) {
+            return Ok(());
+        }
+
         if !self.watches.contains(path) {
             debug!("watching path"; "path" => path.to_str());
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->

## Overview

They are currently excluded in `add_path_recursively`, but not in
`add_path`.  This seems like an oversight.

I tested this change by switching the `debug!` calls in `add_path` to `info!` and observing that a large number of files in `/nix/store` were logged.

To fix this I have added the same guard used in `add_path_recursively` to `add_path`.

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/CONTRIBUTING.md for more on how to structure a pull request.
-->

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [ ] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

