### PR TITLE
readDir: do not watch directories recursively

### DIFF
--- a/src/build_loop.rs
+++ b/src/build_loop.rs
@@ -193,7 +193,10 @@ impl<'a> BuildLoop<'a> {
         self.root_result(run_result.result)
     }
 
-    fn register_paths(&mut self, path_refs: &[builder::ReferencedPath]) -> Result<(), notify::Error> {
+    fn register_paths(
+        &mut self,
+        path_refs: &[builder::ReferencedPath],
+    ) -> Result<(), notify::Error> {
         // Get the paths for which the watching should apply to their
         // subdirectories.
         let paths = builder::recursive_paths(&path_refs);
@@ -214,16 +217,18 @@ impl<'a> BuildLoop<'a> {
         // Exclude anything that is already part of a directory tree
         // that will be watched as part of `paths`.
         let paths_not_rec = paths_not_rec
-                .iter()
-                .filter(|p| !paths.iter().any(|path| p.starts_with(path)))
-                .cloned()
-                .collect::<Vec<_>>();
+            .iter()
+            .filter(|p| !paths.iter().any(|path| p.starts_with(path)))
+            .cloned()
+            .collect::<Vec<_>>();
         debug!("paths_not_rec reduced"; "from" => original_paths_not_rec_len,
             "to" => paths_not_rec.len());
 
         // add all new (reduced) nix sources to the input source watchlist
-        self.watch.extend(&paths.into_iter().collect::<Vec<_>>(),
-            paths_not_rec.as_slice())?;
+        self.watch.extend(
+            &paths.into_iter().collect::<Vec<_>>(),
+            paths_not_rec.as_slice(),
+        )?;
 
         Ok(())
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -50,22 +50,30 @@ pub enum ReferencedPath {
 /// Extract just the paths that should be watched recursively
 pub fn recursive_paths(referenced_paths: &[ReferencedPath]) -> Vec<PathBuf> {
     let mut paths = Vec::new();
-    paths.extend(referenced_paths.iter().filter_map(|ref_path|
-        match ref_path {
-            ReferencedPath::Recursive(p) => Some(p),
-            _ => None,
-        }).cloned());
+    paths.extend(
+        referenced_paths
+            .iter()
+            .filter_map(|ref_path| match ref_path {
+                ReferencedPath::Recursive(p) => Some(p),
+                _ => None,
+            })
+            .cloned(),
+    );
     paths
 }
 
 /// Extract just the paths that should be watched (but not recursively)
 pub fn not_recursive_paths(referenced_paths: &[ReferencedPath]) -> Vec<PathBuf> {
     let mut paths = Vec::new();
-    paths.extend(referenced_paths.iter().filter_map(|ref_path|
-        match ref_path {
-            ReferencedPath::NotRecursive(p) => Some(p),
-            _ => None,
-        }).cloned());
+    paths.extend(
+        referenced_paths
+            .iter()
+            .filter_map(|ref_path| match ref_path {
+                ReferencedPath::NotRecursive(p) => Some(p),
+                _ => None,
+            })
+            .cloned(),
+    );
     paths
 }
 
@@ -489,9 +497,9 @@ dir-as-source = ./dir;
         let cas = ContentAddressable::new(cas_tmp.path().join("cas"))?;
 
         let inst_info = instrumented_instantiation(&NixFile::Shell(shell), &cas).unwrap();
-        let paths = not_recursive_paths (&inst_info.referenced_paths);
+        let paths = not_recursive_paths(&inst_info.referenced_paths);
         let ends_with = |end| paths.iter().any(|p| p.ends_with(end));
-        let rec_paths = recursive_paths (&inst_info.referenced_paths);
+        let rec_paths = recursive_paths(&inst_info.referenced_paths);
         let rec_ends_with = |end| rec_paths.iter().any(|p| p.ends_with(end));
         assert!(
             ends_with("foo/default.nix"),
@@ -593,7 +601,7 @@ in
 
         let inst_info = instrumented_instantiation(&NixFile::Services(services), &cas).unwrap();
 
-        let paths = not_recursive_paths (&inst_info.referenced_paths);
+        let paths = not_recursive_paths(&inst_info.referenced_paths);
         let ends_with = |end| paths.iter().any(|p| p.ends_with(end));
         assert!(
             ends_with("program1/default.nix"),

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -109,12 +109,15 @@ impl Watch {
     /// Extend the watch list with an additional list of paths.
     /// Note: Watch maintains a list of already watched paths, and
     /// will not add duplicates.
-    pub fn extend(&mut self, paths: &[PathBuf]) -> Result<(), notify::Error> {
+    pub fn extend(&mut self, paths: &[PathBuf], paths_not_rec: &[PathBuf]) -> Result<(), notify::Error> {
         for path in paths {
             self.add_path(&path)?;
             if path.is_dir() {
                 self.add_path_recursively(&path)?;
             }
+        }
+        for path in paths_not_rec {
+            self.add_path(&path)?;
         }
 
         Ok(())

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -334,7 +334,7 @@ mod tests {
         let temp = tempdir().unwrap();
 
         expect_bash(r#"mkdir -p "$1""#, &[temp.path().as_os_str()]);
-        watcher.extend(&[temp.path().to_path_buf()]).unwrap();
+        watcher.extend(&[temp.path().to_path_buf()], &[]).unwrap();
 
         expect_bash(r#"touch "$1/foo""#, &[temp.path().as_os_str()]);
         sleep(upper_watcher_timeout());
@@ -352,7 +352,7 @@ mod tests {
 
         expect_bash(r#"mkdir -p "$1""#, &[temp.path().as_os_str()]);
         expect_bash(r#"touch "$1/foo""#, &[temp.path().as_os_str()]);
-        watcher.extend(&[temp.path().join("foo")]).unwrap();
+        watcher.extend(&[temp.path().join("foo")], &[]).unwrap();
         macos_eat_late_notifications(&mut watcher);
 
         expect_bash(r#"echo 1 > "$1/foo""#, &[temp.path().as_os_str()]);
@@ -368,7 +368,7 @@ mod tests {
 
         expect_bash(r#"mkdir -p "$1""#, &[temp.path().as_os_str()]);
         expect_bash(r#"touch "$1/foo""#, &[temp.path().as_os_str()]);
-        watcher.extend(&[temp.path().join("foo")]).unwrap();
+        watcher.extend(&[temp.path().join("foo")], &[]).unwrap();
         macos_eat_late_notifications(&mut watcher);
 
         // bar is not watched, expect error

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -109,7 +109,11 @@ impl Watch {
     /// Extend the watch list with an additional list of paths.
     /// Note: Watch maintains a list of already watched paths, and
     /// will not add duplicates.
-    pub fn extend(&mut self, paths: &[PathBuf], paths_not_rec: &[PathBuf]) -> Result<(), notify::Error> {
+    pub fn extend(
+        &mut self,
+        paths: &[PathBuf],
+        paths_not_rec: &[PathBuf],
+    ) -> Result<(), notify::Error> {
         for path in paths {
             self.add_path(&path)?;
             if path.is_dir() {


### PR DESCRIPTION
Fixes #152 without breaking "copied source" (see #232).  To do this it:

  * Adds a `ReferencedPath` type to differentiate `Recusive` and
    `NotRecursive` path references found in the nix-instanciate output.
  * Applies the `reduce_paths` function only to the `Recursive`
    paths.
  * Uses the result of `reduce_paths` filter out any `NotRecursive`
    paths that would already be watched.
  * Calls `add_path_recursively` only for the `Recursive` paths.
  * Calls `add_path` for both types.

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [ ] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

