### PR TITLE
safely handle spaces in PATH

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -6,6 +6,12 @@
     # Find the current version number with `git log --pretty=%h | wc -l`
     entries = [
       {
+        version = 517;
+        changes = ''
+          - Fix issue with spaces in PATH entries
+        '';
+      }
+      {
         version = 510;
         changes = ''
           - The shell.nix template used by `lorri init` was changed to take

--- a/src/ops/direnv/envrc.bash
+++ b/src/ops/direnv/envrc.bash
@@ -55,7 +55,7 @@ function prepend() {
     # reference, plus the current (updated on the export) contents.
     # however, exclude the ${separator} unless ${original} starts
     # with a value
-    eval "$varname=${!varname}${original:+${separator}${original}}"
+    eval "$varname=\"${!varname}${original:+${separator}${original}}\""
 }
 
 function append() {

--- a/tests/integration/envrc.rs
+++ b/tests/integration/envrc.rs
@@ -76,3 +76,21 @@ fn v2_gopath_previously_unset() {
 
     assert_eq!(env.get_env("GOPATH"), DirenvValue::Value("BAR"));
 }
+
+#[test]
+fn bug18_path_with_spaces() {
+    let exemplar = "/mnt/c/Program Files (x86)/QuickTime/QTSystem";
+    let path = env::var("PATH")
+        .map(|x| format!("{}:{}", x, exemplar))
+        .unwrap();
+    let env = EnvrcTestCase::new()
+        .ambient_env("PATH", &path)
+        .project_env(ProjectEnvBuilderV1::new().set("PATH", "/foo/bar"))
+        .unwrap()
+        .get_direnv_variables();
+
+    assert_eq!(
+        env.get_env("PATH"),
+        DirenvValue::Value(&format!("/foo/bar:{}", &path))
+    );
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/blob/master/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->
Closes #18.

## Overview

Quoting the value of variable in the prepend function prevents `eval` from treating everything after a space as another command to evaluate.

```
❯ echo $PATH
/Users/blades/.nix-profile/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/VMware Fusion.app/Contents/Public:/Library/TeX/texbin

❯ lorri shell
lorri: building environment......... done
/Users/blades/Library/Caches/com.github.target.lorri.lorri.lorri/cas/fe2381e5f5b538e916a10973b0a6dea1: line 61: Fusion.app/Contents/Public:/Library/TeX/texbin: No such file or directory

❯ ./target/debug/lorri shell
lorri: building environment......... done
```
<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/blob/master/CONTRIBUTING.md for more on how to structure a pull request.
-->

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

~- [ ] Updated the documentation (code documentation, command help, ...)~
- [x] Tested the change (unit or integration tests)
- [x] Amended the changelog in `release.nix` (see `release.nix` for instructions)

