### PR TITLE
daemon: Make it possible to pass `substituters` and `builders`

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -6,6 +6,14 @@
     # Find the current version number with `git log --pretty=%h | wc -l`
     entries = [
       {
+        version = 572;
+        changes = ''
+          `lorri daemon` got a `--extra-nix-options` flag to pass further options
+          to nix as a JSON object, or at least a subset.
+          `builders` and `substituters` is supported for now.
+        '';
+      }
+      {
         version = 568;
         changes = ''
           Added the `$IN_LORRI_SHELL` environment variable to allow

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,7 +47,7 @@ pub enum Command {
 
     /// Start the multi-project daemon. Replaces `lorri watch`
     #[structopt(name = "daemon")]
-    Daemon,
+    Daemon(DaemonOptions),
 
     /// Upgrade Lorri
     #[structopt(name = "self-upgrade", alias = "self-update")]
@@ -116,6 +116,33 @@ pub struct WatchOptions {
     /// Exit after a the first build
     #[structopt(long = "once")]
     pub once: bool,
+}
+
+/// Options for the `daemon` subcommand
+#[derive(StructOpt, Debug)]
+pub struct DaemonOptions {
+    #[structopt(
+        long = "extra-nix-options",
+        parse(try_from_str = "serde_json::from_str")
+    )]
+    /// JSON value of nix config options to add.
+    /// Only a subset is supported:
+    /// {
+    ///   "builders": <optional list of string>,
+    ///   "substituters": <optional list of string>
+    /// }
+    pub extra_nix_options: Option<NixOptions>,
+}
+
+/// The nix options we can parse as json string
+#[derive(Deserialize, Debug)]
+// ATTN: If you modify this,
+// adjust the help text in DaemonOptions.extra_nix_options
+pub struct NixOptions {
+    /// `builders` (see `nix::options::NixOptions`)
+    pub builders: Option<Vec<String>>,
+    /// `substituters` (see `nix::options::NixOptions`)
+    pub substituters: Option<Vec<String>>,
 }
 
 /// Sub-commands which lorri can execute for internal features

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,9 +101,9 @@ fn run_command(log: slog::Logger, opts: Arguments) -> OpResult {
             let (project, _guard) = with_project(&opts.nix_file)?;
             watch::main(project, opts)
         }
-        Command::Daemon => {
+        Command::Daemon(opts) => {
             let _guard = without_project();
-            daemon::main()
+            daemon::main(opts)
         }
         Command::Upgrade(opts) => {
             let _guard = without_project();

--- a/src/nix/options.rs
+++ b/src/nix/options.rs
@@ -1,0 +1,90 @@
+/// These options correspond to the nix options in `man nix.conf`
+/// with the same names, though we only support a subset.
+///
+/// You can use `.append(other)` to merge another `NixOptions`.
+#[derive(Clone)]
+pub struct NixOptions {
+    /// List of nix `builder` specifications
+    ///
+    /// * `None` use the ones configured in the nix config
+    /// * `Some([])`: use no builders
+    /// * `Some(list)`: use exactly `list`
+    pub builders: Option<Vec<String>>,
+    /// `substituter` hostnames
+    ///
+    /// * `None`: use the ones configured in the nix config
+    /// * `Some([])`: use no substituters
+    /// *`Some(list)`: use exactly `list`
+    pub substituters: Option<Vec<String>>,
+}
+
+impl NixOptions {
+    /// No extra options. Empty element.
+    pub fn empty() -> Self {
+        NixOptions {
+            builders: None,
+            substituters: None,
+        }
+    }
+
+    /// Combine the two optional lists, so that they are concatenated
+    /// if both are `Some` and otherwise the one that exists is used.
+    fn extend_option_vec(v1: &mut Option<Vec<String>>, v2: Option<Vec<String>>) {
+        match v1.as_mut() {
+            Some(v1) => {
+                if let Some(v2) = v2 {
+                    v1.extend(v2)
+                }
+            }
+            None => {
+                if let Some(v2) = v2 {
+                    drop(v1.replace(v2))
+                }
+            }
+        }
+    }
+
+    /// Append nix options semantically.
+    ///
+    /// This means for the extra options:
+    /// - The `builders` list is appended to on the right (if both exist),
+    ///   otherwise the existing one is used (or `None` if both are `None`).
+    /// - Same for `substituters`.
+    ///
+    /// `empty()` and `append()` form a monoid.
+    pub fn append(&mut self, other: Self) {
+        Self::extend_option_vec(&mut self.builders, other.builders);
+        Self::extend_option_vec(&mut self.substituters, other.substituters);
+    }
+
+    /// At the moment there is no distinction between
+    /// `nix-instantiate` and `nix-store`)
+    pub fn to_nix_arglist(&self) -> Vec<String> {
+        let Self {
+            ref builders,
+            ref substituters,
+        } = self;
+
+        let mut builders_vec = match builders {
+            Some(bs) => vec![
+                "--builders".to_owned(),
+                // The --builders argument takes the same format as /etc/nix/machines,
+                // which means one line per builder specification.
+                bs.join("\n"),
+            ],
+            None => vec![],
+        };
+
+        let substituters_vec = match substituters {
+            Some(ss) => vec![
+                // --substituters are joined “by whitespace” according to `man nix.conf`.
+                "--substituters".to_owned(),
+                ss.join(" "),
+            ],
+            None => vec![],
+        };
+
+        builders_vec.extend(substituters_vec);
+        builders_vec
+    }
+}

--- a/src/ops/daemon.rs
+++ b/src/ops/daemon.rs
@@ -2,13 +2,22 @@
 //! Can be used together with `direnv`.
 
 use crate::daemon::Daemon;
+use crate::nix::options::NixOptions;
 use crate::ops::error::{ok, OpResult};
 use crate::socket::SocketPath;
 use slog_scope::info;
 
 /// See the documentation for lorri::cli::Command::Daemon for details.
-pub fn main() -> OpResult {
-    let (daemon, build_rx) = Daemon::new();
+pub fn main(opts: crate::cli::DaemonOptions) -> OpResult {
+    let extra_nix_options = match opts.extra_nix_options {
+        None => NixOptions::empty(),
+        Some(v) => NixOptions {
+            builders: v.builders,
+            substituters: v.substituters,
+        },
+    };
+
+    let (daemon, build_rx) = Daemon::new(extra_nix_options);
     let build_handle = std::thread::spawn(|| {
         for msg in build_rx {
             info!("build status"; "message" => ?msg);

--- a/src/ops/shell.rs
+++ b/src/ops/shell.rs
@@ -107,7 +107,12 @@ fn build_root(project: &Project, cached: bool) -> Result<PathBuf, ExitError> {
         eprintln!(". done");
     });
 
-    let run_result = builder::run(&project.nix_file, &project.cas);
+    // TODO: add the ability to pass extra_nix_options to shell
+    let run_result = builder::run(
+        &project.nix_file,
+        &project.cas,
+        &crate::nix::options::NixOptions::empty(),
+    );
     building.store(false, Ordering::SeqCst);
     progress_thread.join().unwrap();
 

--- a/src/ops/watch.rs
+++ b/src/ops/watch.rs
@@ -3,6 +3,7 @@
 
 use crate::build_loop::BuildLoop;
 use crate::cli::WatchOptions;
+use crate::nix::options::NixOptions;
 use crate::ops::error::{ok, ExitError, OpResult};
 use crate::project::Project;
 use crossbeam_channel as chan;
@@ -21,7 +22,8 @@ pub fn main(project: Project, opts: WatchOptions) -> OpResult {
 }
 
 fn main_run_once(project: Project) -> OpResult {
-    let mut build_loop = BuildLoop::new(&project);
+    // TODO: add the ability to pass extra_nix_options to watch
+    let mut build_loop = BuildLoop::new(&project, NixOptions::empty());
     match build_loop.once() {
         Ok(msg) => {
             print_build_message(msg);
@@ -41,7 +43,8 @@ fn main_run_forever(project: Project) -> OpResult {
     let (tx, rx) = chan::unbounded();
     let build_thread = {
         thread::spawn(move || {
-            let mut build_loop = BuildLoop::new(&project);
+            // TODO: add the ability to pass extra_nix_options to watch
+            let mut build_loop = BuildLoop::new(&project, NixOptions::empty());
 
             // The `watch` command does not currently react to pings, hence the `chan::never()`
             build_loop.forever(tx, chan::never());

--- a/tests/daemon/main.rs
+++ b/tests/daemon/main.rs
@@ -1,6 +1,7 @@
 use lorri::build_loop;
 use lorri::cas::ContentAddressable;
 use lorri::daemon::{Daemon, LoopHandlerEvent};
+use lorri::nix::options::NixOptions;
 use lorri::rpc;
 use lorri::socket::SocketPath;
 use std::io::{Error, ErrorKind};
@@ -28,7 +29,7 @@ pub fn start_job_with_ping() -> std::io::Result<()> {
     let gc_root_dir = tempdir.path().join("gc_root").to_path_buf();
 
     // The daemon knows how to build stuff
-    let (daemon, build_rx) = Daemon::new();
+    let (daemon, build_rx) = Daemon::new(NixOptions::empty());
     let accept_handle = thread::spawn(move || {
         daemon
             .serve(socket_path, gc_root_dir, cas)

--- a/tests/integration/direnvtestcase.rs
+++ b/tests/integration/direnvtestcase.rs
@@ -5,6 +5,7 @@ use lorri::{
     build_loop::{BuildLoop, BuildResults},
     cas::ContentAddressable,
     error::BuildError,
+    nix::options::NixOptions,
     ops::direnv,
     project::Project,
     NixFile,
@@ -52,7 +53,7 @@ impl DirenvTestCase {
 
     /// Execute the build loop one time
     pub fn evaluate(&mut self) -> Result<BuildResults, BuildError> {
-        BuildLoop::new(&self.project).once()
+        BuildLoop::new(&self.project, NixOptions::empty()).once()
     }
 
     /// Run `direnv allow` and then `direnv export json`, and return

--- a/tests/shell/main.rs
+++ b/tests/shell/main.rs
@@ -1,6 +1,7 @@
 use lorri::{
     builder,
     cas::ContentAddressable,
+    nix::options::NixOptions,
     ops::shell,
     project::{roots::Roots, Project},
     NixFile,
@@ -74,7 +75,7 @@ fn build(project: &Project) -> PathBuf {
     Path::new(
         Roots::from_project(&project)
             .create_roots(
-                builder::run(&project.nix_file, &project.cas)
+                builder::run(&project.nix_file, &project.cas, &NixOptions::empty())
                     .unwrap()
                     .result,
             )


### PR DESCRIPTION
Adds the ability to input additional nix arguments through to the nix
commands. For our sanity and so that we don’t have to replicate the
whole nix API, they are passed as json string on the command line.

However, I don’t know how an exhaustive API would look like (nix has a
lot of configuration options and their semantics is pretty weird in
places), so I opted to only add `--substituters` and `--builders`. We
even gain a nicer interface by using an optional list.

I’m not yet positive on how to document the JSON interface more
nicely, maybe we do want to expose all options as command line flags,
but I really don’t know how that would look without leading to a mess.

The changes are rather simple and mostly mechanical.

As a followup, we should add the same flag to `watch` and `shell`.

cc @curiousleo @nyarly 

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [x] Updated the documentation (code documentation, command help, ...)
- [x] Tested the change (unit or integration tests)
- [x] Amended the changelog in `release.nix` (see `release.nix` for instructions)

