### PR TITLE
ops: banish underscores in cli commands

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -6,6 +6,14 @@
     # Find the current version number with `git log --pretty=%h | wc -l`
     entries = [
       {
+        version = 534;
+        changes = ''
+          Rename `lorri internal` commands for consistency:
+            - `start_user_shell` -> `start-user-shell`
+            - `stream_events` -> `stream-events`
+        '';
+      }
+      {
         version = 518;
         changes = ''
           Internal subcommands is now visible for all users inside the internal

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,7 +96,7 @@ pub struct ShellOptions {
     pub cached: bool,
 }
 
-/// Options for the `internal start_user_shell` subcommand.
+/// Options for the `internal start-user-shell` subcommand.
 #[derive(StructOpt, Debug)]
 pub struct StartUserShellOptions_ {
     /// The path of the parent shell's binary
@@ -122,7 +122,7 @@ pub struct WatchOptions {
 #[derive(StructOpt, Debug)]
 pub enum Internal_ {
     /// (internal) Used internally by `lorri shell`
-    #[structopt(name = "start_user_shell")]
+    #[structopt(name = "start-user-shell")]
     StartUserShell_(StartUserShellOptions_),
 
     /// (plumbing) Tell the lorri daemon to care about the current directory's project
@@ -130,7 +130,7 @@ pub enum Internal_ {
     Ping_(Ping_),
 
     /// (plumbing) Ask the lorri daemon to report build events as they occur
-    #[structopt(name = "stream_events")]
+    #[structopt(name = "stream-events")]
     StreamEvents_(StreamEvents_),
 }
 

--- a/src/ops/shell.rs
+++ b/src/ops/shell.rs
@@ -29,7 +29,7 @@ use std::{env, thread};
 /// ├── builds the project environment if --cached is false
 /// ├── writes a bash init script that loads the project environment
 /// ├── SPAWNS bash with the init script as its `--rcfile`
-/// │   └── EXECS `lorri internal start_user_shell`
+/// │   └── EXECS `lorri internal start-user-shell`
 /// │       ├── (*) performs shell-specific setup for $SHELL
 /// │       └── EXECS into user shell $SHELL
 /// │           └── interactive user shell
@@ -55,7 +55,7 @@ pub fn main(project: Project, opts: ShellOptions) -> OpResult {
     let status = bash_cmd
         .args(&[
             "-c",
-            "exec \"$1\" internal start_user_shell --shell-path=\"$2\" --shell-file=\"$3\"",
+            "exec \"$1\" internal start-user-shell --shell-path=\"$2\" --shell-file=\"$3\"",
             "--",
             &lorri
                 .to_str()


### PR DESCRIPTION
Either we do `-` or `_`, and we already use `-` for all flags and
`self-upgrade`. Consistency is king for good UX.

This is obviously a breaking change, but these are `internal` and haven’t seen an official release so far (plus we added the `internal`-as-a-subcommand thing recently anyway).

cc @curiousleo @nyarly 