### PR TITLE
Fix README (direnv shouldn't be auto-installed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ platforms](#setup-on-other-platforms).
    NixOS [`configuration.nix`][nixos-service] or your home-manager
    [`home.nix`][home-manager-service].
 
-   This will automatically install both the `lorri` command and `direnv`
-   (both required for the next steps).
+   This will automatically install the `lorri` command.
 
 2. **Install direnv.** Add `pkgs.direnv` to `environment.systemPackages` in
    your NixOS `configuration.nix` or to `home.packages` in your home-manager


### PR DESCRIPTION
## Overview

Direnv isn't and shouldn't be automatially installed on installing lorri, per https://github.com/NixOS/nixpkgs/pull/85144

## Checklist

- [x] Updated the documentation (code documentation, command help, ...)
- [x] Tested the change (unit or integration tests)

