### PR TITLE
src/trivial-shell.nix: add bashInteractive

### DIFF
--- a/src/trivial-shell.nix
+++ b/src/trivial-shell.nix
@@ -3,5 +3,8 @@
 pkgs.mkShell {
   buildInputs = [
     pkgs.hello
+
+    # keep this line if you use bash
+    pkgs.bashInteractive
   ];
 }


### PR DESCRIPTION
For bash users, `mkShell` overrides their path with a non-interactive
shell, which breaks their shells.

Adding `bashInteractive` is a workaround, so we should recommend that
and add it via `lorri init`.

Closes https://github.com/target/lorri/issues/383

cc @deliciouslytyped

