### PR TITLE
CI runs against nixos-20.03 now

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -66,9 +66,11 @@ To cut a new release:
 
 ## Publishing a release on [nixpkgs][]
 
-lorri is available in the `nixos-unstable` and `nixos-19.09` release channels,
-which correspond to the `master` and `release-19.09` branches in the
-[nixpkgs][] repository, respectively.
+lorri is available in the `nixos-unstable` and release channels starting with
+`nixos-19.09`.
+
+lorri is built and tested against `nixos-20.03` in CI, and this is the release
+channel targeted for future releases.
 
 The relevant directories and files in [nixpkgs][] are:
 - [`pkgs/tools/misc/lorri`][nixpkgs-lorri-tool] declares the command line tool
@@ -86,9 +88,9 @@ To update the lorri version in [nixpkgs][]:
 
    > @GrahamcOfBorg build lorri.tests
 
-2. **`nixos-19.09`**: _after_ the first PR has been merged into `master`,
+2. **`nixos-<release>`**: _after_ the first PR has been merged into `master`,
    follow the [backporting procedure][nixpkgs-backporting] to create a PR
-   against `release-19.09`; see for example [NixOS#77432][nixos-stable-pr].
+   against `release-<release>`; see for example [NixOS#77432][nixos-stable-pr].
    Again, make sure the NixOS integration tests pass (see previous step).
 
 ## Updating dependencies


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/blob/master/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->
Follow-up to https://github.com/target/lorri/pull/396#discussion_r422865040.

## Overview

Document the fact that CI runs against nixos-20.03 now.

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/blob/master/CONTRIBUTING.md for more on how to structure a pull request.
-->

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [x] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

