### PR TITLE
Use IN_LORRI_SHELL to auto detect shell.nix

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,7 +70,12 @@ pub enum Command {
 #[derive(StructOpt, Debug)]
 pub struct DirenvOptions {
     /// The .nix file in the current directory to use
-    #[structopt(long = "shell-file", parse(from_os_str), default_value = "shell.nix")]
+    #[structopt(
+        long = "shell-file",
+        parse(from_os_str),
+        env = "IN_LORRI_SHELL",
+        default_value = "shell.nix"
+    )]
     pub nix_file: PathBuf,
 }
 
@@ -81,7 +86,7 @@ pub struct InfoOptions {
     // The "shell-file" argument has no default value. That's on purpose: sometimes users have
     // projects with multiple shell files. This way, they are forced to think about which shell
     // file was causing problems when they submit a bug report.
-    #[structopt(long = "shell-file", parse(from_os_str))]
+    #[structopt(long = "shell-file", parse(from_os_str), env = "IN_LORRI_SHELL")]
     pub nix_file: PathBuf,
 }
 
@@ -89,7 +94,12 @@ pub struct InfoOptions {
 #[derive(StructOpt, Debug)]
 pub struct ShellOptions {
     /// The .nix file in the current directory to use
-    #[structopt(long = "shell-file", parse(from_os_str), default_value = "shell.nix")]
+    #[structopt(
+        long = "shell-file",
+        parse(from_os_str),
+        env = "IN_LORRI_SHELL",
+        default_value = "shell.nix"
+    )]
     pub nix_file: PathBuf,
     /// If true, load environment from cache
     #[structopt(long = "cached")]
@@ -111,7 +121,12 @@ pub struct StartUserShellOptions_ {
 #[derive(StructOpt, Debug)]
 pub struct WatchOptions {
     /// The .nix file in the current directory to use
-    #[structopt(long = "shell-file", parse(from_os_str), default_value = "shell.nix")]
+    #[structopt(
+        long = "shell-file",
+        parse(from_os_str),
+        env = "IN_LORRI_SHELL",
+        default_value = "shell.nix"
+    )]
     pub nix_file: PathBuf,
     /// Exit after a the first build
     #[structopt(long = "once")]

--- a/src/locate_file.rs
+++ b/src/locate_file.rs
@@ -2,6 +2,7 @@
 
 use std::env;
 use std::io;
+use std::path::Path;
 use std::path::PathBuf;
 
 /// Error conditions encountered when hunting for a file on disk
@@ -13,6 +14,9 @@ pub enum FileLocationError {
 
     /// No file by this name was found
     NotFound,
+
+    /// The specified file is not part of project in current directory
+    PathNotInProject,
 }
 
 impl From<std::io::Error> for FileLocationError {
@@ -21,12 +25,27 @@ impl From<std::io::Error> for FileLocationError {
     }
 }
 
-/// Hunt for filename `name` in the current directory
-pub fn in_cwd(name: &PathBuf) -> Result<PathBuf, FileLocationError> {
-    let mut path = env::current_dir()?;
-    path.push(name);
+/// If `name` is relative path, hunt in current directory
+/// else if `name` is absolute path, hunt in a parent directory.
+pub fn by_name(name: &PathBuf) -> Result<PathBuf, FileLocationError> {
+    let cwd = env::current_dir()?;
+    in_cwd(&cwd, name)
+}
+
+fn in_cwd(cwd: &Path, name: &PathBuf) -> Result<PathBuf, FileLocationError> {
+    let path = if name.is_absolute() {
+        name.to_path_buf()
+    } else {
+        cwd.join(name)
+    };
+
     if path.is_file() {
-        Ok(path)
+        let parent = path.parent().unwrap();
+        if cwd.ancestors().any(|a| a == parent) {
+            Ok(path.to_path_buf())
+        } else {
+            Err(FileLocationError::PathNotInProject)
+        }
     } else {
         Err(FileLocationError::NotFound)
     }
@@ -34,27 +53,65 @@ pub fn in_cwd(name: &PathBuf) -> Result<PathBuf, FileLocationError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{in_cwd, FileLocationError};
+    use super::{by_name, in_cwd, FileLocationError};
+    use std::env;
     use std::path::Path;
     use std::path::PathBuf;
 
     #[test]
-    fn test_locate_config_file() {
-        let mut path = PathBuf::from("shell.nix");
-        let result = in_cwd(&path);
-        assert_eq!(
-            result.expect("Should find the shell.nix in this projects' root"),
-            Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("shell.nix")
-                .to_path_buf()
-        );
-        path.pop();
-        path.push("this-lorri-specific-file-probably-does-not-exist");
-        let result = in_cwd(&path);
+    fn test_locate_config_file_by_name() {
+        let cwd = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let name = PathBuf::from("shell.nix");
+        let abs_path = cwd.join(name.to_path_buf());
 
+        let result = by_name(&name);
+        assert_eq!(
+            result.expect("Should find the shell.nix by name in this projects' root"),
+            abs_path
+        );
+
+        let result = by_name(&abs_path);
+        assert_eq!(
+            result.expect("Should find the shell.nix in current directory by full path"),
+            abs_path
+        );
+
+        let result = by_name(&PathBuf::from("lorri-nix-file?-bveuy5guk"));
         match result {
             Err(FileLocationError::NotFound) => (),
-            _ => panic!("unexpected result: {:?}", result),
+            _ => panic!("Should not non existing file: {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_locate_config_file_in_cwd() {
+        let cwd = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let name = PathBuf::from("shell.nix");
+        let abs_path = cwd.join(name.to_path_buf());
+
+        let subdir = cwd.join("src");
+        let result = in_cwd(&subdir, &abs_path);
+        assert_eq!(
+            result.expect("Should find the shell.nix in ./src directory by full path"),
+            abs_path
+        );
+
+        let result = in_cwd(&subdir, &name);
+        match result {
+            Err(FileLocationError::NotFound) => (),
+            _ => panic!("Should not find by name in ./src directory: {:?}", result),
+        }
+
+        let result = in_cwd(&cwd.parent().unwrap(), &abs_path);
+        match result {
+            Err(FileLocationError::PathNotInProject) => (),
+            _ => panic!("Should not find by path ouside project: {:?}", result),
+        }
+
+        let result = in_cwd(&env::temp_dir(), &abs_path);
+        match result {
+            Err(FileLocationError::PathNotInProject) => (),
+            _ => panic!("Should not find by path ouside project: {:?}", result),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 
 const TRIVIAL_SHELL_SRC: &str = include_str!("./trivial-shell.nix");
-const DEFAULT_ENVRC: &str = "eval \"$(lorri direnv)\"\n";
+const DEFAULT_ENVRC: &str = "eval \"$(lorri direnv --shell-file=shell.nix)\"\n";
 
 fn main() {
     // This returns 101 on panics, see also `ExitError::panic`.
@@ -48,7 +48,7 @@ fn main() {
 /// Try to read `shell.nix` from the current working dir.
 fn get_shell_nix(shellfile: &PathBuf) -> Result<NixFile, ExitError> {
     // use shell.nix from cwd
-    Ok(NixFile::Shell(locate_file::in_cwd(&shellfile).map_err(
+    Ok(NixFile::Shell(locate_file::by_name(&shellfile).map_err(
         |_| {
             ExitError::user_error(format!(
                 "`{}` does not exist\n\

--- a/src/ops/info.rs
+++ b/src/ops/info.rs
@@ -3,6 +3,7 @@
 use crate::builder::OutputPaths;
 use crate::ops::error::{ok, OpResult};
 use crate::project::{roots::Roots, Project};
+use std::path::PathBuf;
 
 /// See the documentation for lorri::cli::Command::Info for more
 /// details.
@@ -10,6 +11,10 @@ pub fn main(project: Project) -> OpResult {
     println!("lorri version: {}", crate::LORRI_VERSION);
     let root_paths = Roots::from_project(&project).paths();
     let OutputPaths { shell_gc_root } = &root_paths;
+    println!(
+        "Nix shell file: {}",
+        PathBuf::from(&project.nix_file).display()
+    );
     if root_paths.all_exist() {
         println!(
             "GC roots exist, shell_gc_root: {:?}",


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/blob/master/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->
Closes #409.

## Overview

The IN_LORRI_SHELL environment variable points to current shell.nix
file. If this environment variable points to a file in any parent
directory of current working directory, then this shell file is used 
as the default value for `--shell-file` argument for commands.

This is my first time writing rust code so please be patient with me till I get the code & tests right.
<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/blob/master/CONTRIBUTING.md for more on how to structure a pull request.
-->

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [ ] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

