### PR TITLE
ci: ensure compatibility with 19.09

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,5 +81,7 @@ jobs:
         uses: cachix/install-nix-action@v9
         with:
             skip_adding_nixpkgs_channel: true
-      - name: Build w/ overlay
-        run: nix-build ./nix/overlay.nix -A lorri
+      - name: Build w/ overlay (19.09)
+        run: nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-1909.json
+      - name: Build w/ overlay (stable)
+        run: nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-stable.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,15 @@ on:
   pull_request:
     branches: [ "**" ]
 jobs:
-  build:
+  rust:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Nix
-        uses: cachix/install-nix-action@v7
+        uses: cachix/install-nix-action@v9
+        with:
+            skip_adding_nixpkgs_channel: true
       - name: Cache cargo registry
         uses: actions/cache@v1
         with:
@@ -37,21 +39,47 @@ jobs:
         run: nix-shell --run 'cargo clippy --all-features' --arg isDevelopmentShell false
       - name: Test
         run: nix-shell --run 'cargo test' --arg isDevelopmentShell false
-  nix-build:
+  nix-build_stable:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Nix
-        uses: cachix/install-nix-action@v7
+        uses: cachix/install-nix-action@v9
+        with:
+            skip_adding_nixpkgs_channel: true
       - name: Build
         run: nix-build
+  nix-build_1909:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Nix
+        uses: cachix/install-nix-action@v9
+        with:
+            skip_adding_nixpkgs_channel: true
+      - name: Build
+        run: nix-build --arg nixpkgs ./nix/nixpkgs-1909.nix
   nix-shell:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Nix
-        uses: cachix/install-nix-action@v7
+        uses: cachix/install-nix-action@v9
+        with:
+            skip_adding_nixpkgs_channel: true
       - name: Build
         run: nix-build -A allBuildInputs shell.nix
+  overlay:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Nix
+        uses: cachix/install-nix-action@v9
+        with:
+            skip_adding_nixpkgs_channel: true
+      - name: Build w/ overlay
+        run: nix-build ./nix/overlay.nix -A lorri

--- a/.travis.yml.nix
+++ b/.travis.yml.nix
@@ -1,5 +1,5 @@
 let
-  pkgs = import ./nix/nixpkgs.nix;
+  pkgs = import ./nix/nixpkgs-stable.nix;
 
   projectname = "lorri";
 

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,5 @@
-{ pkgs ? import ./nix/nixpkgs.nix
+{ nixpkgs ? ./nix/nixpkgs-stable.nix
+, pkgs ? import nixpkgs
 , src ? pkgs.nix-gitignore.gitignoreSource [ ".git/" ] ./.
 }:
 (

--- a/nix/nixpkgs-1909.json
+++ b/nix/nixpkgs-1909.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/nixos/nixpkgs-channels.git",
+  "rev": "35eda4aede5c9c90c6dfc5c4f83cdac7cae59028",
+  "date": "2020-05-23T11:15:35+02:00",
+  "path": "/nix/store/a8krgvvxj4jcph9axyrl2pbwf7bl2bka-nixpkgs-channels",
+  "sha256": "047gkqd304vc07r8kgf13443waaxmhy4skkgj3i2x19cjw7qvl78",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/nix/nixpkgs-1909.nix
+++ b/nix/nixpkgs-1909.nix
@@ -1,5 +1,5 @@
 let
-  srcDef = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+  srcDef = builtins.fromJSON (builtins.readFile ./nixpkgs-1909.json);
   nixpkgs = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${srcDef.rev}.tar.gz";
     sha256 = srcDef.sha256;

--- a/nix/nixpkgs-stable.json
+++ b/nix/nixpkgs-stable.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/nixos/nixpkgs-channels.git",
+  "rev": "e985ffea2d640bb6fe7d5ef7aa968b2b7d107f47",
+  "date": "2020-05-28T17:39:41+02:00",
+  "path": "/nix/store/nzr4s1sj70sib739yc4l4h775q2aaiqp-nixpkgs-channels",
+  "sha256": "01nmwqixbkvnp9y0rkblwik6g0wk95pr9j3wrh1ar72cif47n06l",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/nix/nixpkgs-stable.nix
+++ b/nix/nixpkgs-stable.nix
@@ -1,0 +1,8 @@
+let
+  srcDef = builtins.fromJSON (builtins.readFile ./nixpkgs-stable.json);
+  nixpkgs = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/${srcDef.rev}.tar.gz";
+    sha256 = srcDef.sha256;
+  };
+in
+import nixpkgs {}

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,9 +1,0 @@
-{
-  "url": "https://github.com/nixos/nixpkgs-channels.git",
-  "rev": "d6c1b566b770cf4cf0c6d4a693da6bdf28c2c3b0",
-  "date": "2020-05-09T01:03:45+02:00",
-  "sha256": "00vm9shmpywx9dzaj0c7vap1ldimdsr7lw2n8p70qza87nmp9dai",
-  "fetchSubmodules": false,
-  "deepClone": false,
-  "leaveDotGit": false
-}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -7,8 +7,10 @@ let
 in
 import nixpkgs {
   overlays = [
-    (final: super: {
-      lorri = super.callPackage ../default.nix { };
-    })
+    (
+      final: super: {
+        lorri = super.callPackage ../default.nix {};
+      }
+    )
   ];
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,5 +1,6 @@
+{ pkgs }:
 let
-  srcDef = builtins.fromJSON (builtins.readFile ./nixpkgs-stable.json);
+  srcDef = builtins.fromJSON (builtins.readFile pkgs);
   nixpkgs = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${srcDef.rev}.tar.gz";
     sha256 = srcDef.sha256;

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,14 @@
+let
+  srcDef = builtins.fromJSON (builtins.readFile ./nixpkgs-stable.json);
+  nixpkgs = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/${srcDef.rev}.tar.gz";
+    sha256 = srcDef.sha256;
+  };
+in
+import nixpkgs {
+  overlays = [
+    (final: super: {
+      lorri = super.callPackage ../default.nix { };
+    })
+  ];
+}

--- a/nix/update-dependencies.sh
+++ b/nix/update-dependencies.sh
@@ -6,5 +6,10 @@ set -euo pipefail
 # lorri should always build with the current NixOS stable branch.
 channel='nixos-20.03'
 nix-prefetch-git https://github.com/nixos/nixpkgs-channels.git \
-                 --rev "refs/heads/${channel}" > ./nix/nixpkgs.json
+                 --rev "refs/heads/${channel}" > ./nix/nixpkgs-stable.json
 
+# lorri should also build with 19.09 (the first release with `rustPackages`,
+# which we use for e.g. clippy).
+min_channel='nixos-19.09'
+nix-prefetch-git https://github.com/nixos/nixpkgs-channels.git \
+                 --rev "refs/heads/${min_channel}" > ./nix/nixpkgs-1909.json

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,8 @@
   # required for interactive development (i.e. not necessary
   # on CI). Only when this is enabled, Rust nightly is used.
   isDevelopmentShell ? true
-, pkgs ? import ./nix/nixpkgs.nix
+, nixpkgs ? ./nix/nixpkgs-stable.nix
+, pkgs ? import nixpkgs
 }:
 
 let


### PR DESCRIPTION
There are a few steps I've taken to make this as robust as possible:

0) Add a `nixpkgs` arg to default.nix and shell.nix, allowing us to more
easily specify which nixpkgs to use -- rather than having to use
`nix-build --arg pkgs 'import ./nix/nixpkgs-1909.nix'`, one only needs
to run `nix-build --arg nixpkgs ./nix/nixpkgs-1909.nix`.

1) Create two separate nixpkgs expressions, nixpkgs-stable and
nixpkgs-1909. This allows us to build against NixOS 19.09 by running the
aforementioned `nix-build --arg nixpkgs ./nix/nixpkgs-1909.nix`
commandline. (Also add nixos-19.09 to the update-dependencies script.)

2) Add an `overlay` build step that overlays the lorri available from
the current stable nixpkgs, to ensure that it is still possible to do
so. ("in order to not have to wait on a new lorri release in nixpkgs" --
Profpatsch)

<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/blob/master/CONTRIBUTING.md
-->

---

<!-- Please replace ISSUE by the issue number this pull request addresses. -->
Fixes https://github.com/target/lorri/issues/406.

Also, I updated to the latest action because it lets us drop the use of NIX_PATH/channels since we use our own versions stored in the `.json`s (which ever-so-slightly speeds up CI).

Let me know if there's anything you would like to see improved.

cc @curiousleo @Profpatsch 

