### PR TITLE
trivial-shell.nix: use with

### DIFF
--- a/src/trivial-shell.nix
+++ b/src/trivial-shell.nix
@@ -1,10 +1,10 @@
 { pkgs ? import <nixpkgs> {} }:
 
 pkgs.mkShell {
-  buildInputs = [
-    pkgs.hello
+  buildInputs = with pkgs; [
+    hello
 
     # keep this line if you use bash
-    pkgs.bashInteractive
+    bashInteractive
   ];
 }


### PR DESCRIPTION
To clean up list of packages.

I'm assuming this should not be mentioned in the release notes, since it's a visible and backwards-compatible change with no effect on lorri's semantics, but let me know if it should instead.

<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/blob/master/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->
## Overview

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/blob/master/CONTRIBUTING.md for more on how to structure a pull request.
-->

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [ ] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

