### PR TITLE
Increase test watcher timeout to 1s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Nix
-        uses: cachix/install-nix-action@v7
+        uses: cachix/install-nix-action@v9
+        with:
+            skip_adding_nixpkgs_channel: true
       - name: Cache cargo registry
         uses: actions/cache@v1
         with:
@@ -43,7 +45,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Nix
-        uses: cachix/install-nix-action@v7
+        uses: cachix/install-nix-action@v9
+        with:
+            skip_adding_nixpkgs_channel: true
       - name: Build
         run: nix-build
   nix-shell:
@@ -52,6 +56,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Nix
-        uses: cachix/install-nix-action@v7
+        uses: cachix/install-nix-action@v9
+        with:
+            skip_adding_nixpkgs_channel: true
       - name: Build
         run: nix-build -A allBuildInputs shell.nix

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -316,7 +316,8 @@ mod tests {
 
     /// upper bound of watcher (if it’s hit, something is broken)
     fn upper_watcher_timeout() -> Duration {
-        Duration::from_millis(500)
+        // CI machines are very slow sometimes.
+        Duration::from_millis(1000)
     }
 
     /// Collect all notifications


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/blob/master/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->
Avoids failures like in https://github.com/target/lorri/runs/780067510.

## Overview

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/blob/master/CONTRIBUTING.md for more on how to structure a pull request.
-->

CI machines are terribly slow sometimes. This should make timeout based tests less flaky.

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [ ] Updated the documentation (code documentation, command help, ...)
- [x] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

