### PR TITLE
Thread.rs correctly unwind call stacks

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -84,78 +84,106 @@ impl Daemon {
 
     /// Serve the daemon's RPC endpoint.
     pub fn serve(
-        mut self,
+        self,
         socket_path: SocketPath,
         gc_root_dir: PathBuf,
         cas: crate::cas::ContentAddressable,
     ) -> Result<(), ExitError> {
-        let (activity_tx, activity_rx) = chan::unbounded();
+        let (activity_tx, activity_rx): (
+            chan::Sender<IndicateActivity>,
+            chan::Receiver<IndicateActivity>,
+        ) = chan::unbounded();
 
-        let server = rpc::Server::new(socket_path, activity_tx, self.build_events_tx.clone())?;
         let mut pool = crate::thread::Pool::new();
-        pool.spawn("accept-loop", move || {
-            server
-                .serve()
-                .expect("failed to serve daemon server endpoint");
+        let build_events_tx = self.build_events_tx.clone();
+
+        pool.spawn("accept-loop", || {
+            Self::accept_loop(socket_path, activity_tx, build_events_tx)
         })?;
         let build_events_rx = self.build_events_rx.clone();
         let mon_tx = self.mon_tx.clone();
-        pool.spawn("build-loop", move || {
-            let mut project_states: HashMap<NixFile, Event> = HashMap::new();
-            let mut event_listeners: Vec<chan::Sender<Event>> = Vec::new();
 
-            for msg in build_events_rx {
-                mon_tx
-                    .send(msg.clone())
-                    .expect("listener still to be there");
-                match &msg {
-                    LoopHandlerEvent::BuildEvent(ev) => match ev {
-                        Event::SectionEnd => (),
-                        Event::Started { nix_file, .. }
-                        | Event::Completed { nix_file, .. }
-                        | Event::Failure { nix_file, .. } => {
-                            project_states.insert(nix_file.clone(), ev.clone());
-                            event_listeners.retain(|tx| {
-                                let keep = tx.send(ev.clone()).is_ok();
-                                debug!("Sent"; "event" => ?ev, "keep" => keep);
-                                keep
-                            })
-                        }
-                    },
-                    LoopHandlerEvent::NewListener(tx) => {
-                        debug!("adding listener");
-                        let keep = project_states.values().all(|event| {
-                            let keeping = tx.send(event.clone()).is_ok();
-                            debug!("Sent snapshot"; "event" => ?&event, "keep" => keeping);
-                            keeping
-                        });
-                        debug!("Finished snapshot"; "keep" => keep);
-                        if keep {
-                            event_listeners.push(tx.clone());
-                        }
-                        event_listeners.retain(|tx| {
-                            let keep = tx.send(Event::SectionEnd).is_ok();
-                            debug!("Sent new listener sectionend"; "keep" => keep);
-                            keep
-                        })
-                    }
-                }
-            }
-        })?;
+        pool.spawn("build-loop", || Self::build_loop(build_events_rx, mon_tx))?;
+
         pool.spawn("build-instruction-handler", move || {
-            // For each build instruction, add the corresponding file
-            // to the watch list.
-            for start_build in activity_rx {
-                let project =
-                    crate::project::Project::new(start_build.nix_file, &gc_root_dir, cas.clone())
-                        // TODO: the project needs to create its gc root dir
-                        .unwrap();
-                self.add(project)
-            }
+            self.build_instruction_handler(activity_rx, &gc_root_dir, cas)
         })?;
+
         pool.join_all_or_panic();
 
         Ok(())
+    }
+
+    fn accept_loop(
+        socket_path: SocketPath,
+        activity_tx: chan::Sender<IndicateActivity>,
+        build_events_tx: chan::Sender<LoopHandlerEvent>,
+    ) -> Result<(), ExitError> {
+        let server = rpc::Server::new(socket_path, activity_tx, build_events_tx)?;
+        server.serve()
+    }
+
+    fn build_loop(
+        build_events_rx: chan::Receiver<LoopHandlerEvent>,
+        mon_tx: chan::Sender<LoopHandlerEvent>,
+    ) {
+        let mut project_states: HashMap<NixFile, Event> = HashMap::new();
+        let mut event_listeners: Vec<chan::Sender<Event>> = Vec::new();
+
+        for msg in build_events_rx {
+            mon_tx
+                .send(msg.clone())
+                .expect("listener still to be there");
+            match &msg {
+                LoopHandlerEvent::BuildEvent(ev) => match ev {
+                    Event::SectionEnd => (),
+                    Event::Started { nix_file, .. }
+                    | Event::Completed { nix_file, .. }
+                    | Event::Failure { nix_file, .. } => {
+                        project_states.insert(nix_file.clone(), ev.clone());
+                        event_listeners.retain(|tx| {
+                            let keep = tx.send(ev.clone()).is_ok();
+                            debug!("Sent"; "event" => ?ev, "keep" => keep);
+                            keep
+                        })
+                    }
+                },
+                LoopHandlerEvent::NewListener(tx) => {
+                    debug!("adding listener");
+                    let keep = project_states.values().all(|event| {
+                        let keeping = tx.send(event.clone()).is_ok();
+                        debug!("Sent snapshot"; "event" => ?&event, "keep" => keeping);
+                        keeping
+                    });
+                    debug!("Finished snapshot"; "keep" => keep);
+                    if keep {
+                        event_listeners.push(tx.clone());
+                    }
+                    event_listeners.retain(|tx| {
+                        let keep = tx.send(Event::SectionEnd).is_ok();
+                        debug!("Sent new listener sectionend"; "keep" => keep);
+                        keep
+                    })
+                }
+            }
+        }
+    }
+
+    fn build_instruction_handler(
+        mut self,
+        activity_rx: chan::Receiver<IndicateActivity>,
+        gc_root_dir: &PathBuf,
+        cas: crate::cas::ContentAddressable,
+    ) {
+        // For each build instruction, add the corresponding file
+        // to the watch list.
+        for start_build in activity_rx {
+            let project =
+                crate::project::Project::new(start_build.nix_file, &gc_root_dir, cas.clone())
+                    // TODO: the project needs to create its gc root dir
+                    .unwrap();
+            self.add(project)
+        }
     }
 
     /// Add nix file to the set of files this daemon watches

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -4,7 +4,6 @@ use super::IndicateActivity;
 use super::LoopHandlerEvent;
 use crate::build_loop::Event;
 use crate::error;
-use crate::ops::error::ExitError;
 use crate::rpc;
 use crate::socket::{BindLock, SocketPath};
 use crate::watch;
@@ -29,7 +28,7 @@ impl Server {
         socket_path: SocketPath,
         activity_tx: chan::Sender<IndicateActivity>,
         build_tx: chan::Sender<LoopHandlerEvent>,
-    ) -> Result<Server, ExitError> {
+    ) -> Result<Server, crate::socket::BindError> {
         let lock = socket_path.lock()?;
         Ok(Server {
             socket_path,
@@ -40,7 +39,7 @@ impl Server {
     }
 
     /// Serve the daemon endpoint.
-    pub fn serve(self) -> Result<(), ExitError> {
+    pub fn serve(self) -> Result<(), varlink::error::Error> {
         let address = &self.socket_path.address();
         let service = varlink::VarlinkService::new(
             /* vendor */ "com.target",
@@ -59,7 +58,6 @@ impl Server {
             max_worker_threads,
             idle_timeout,
         )
-        .map_err(|e| ExitError::temporary(format!("{}", e)))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,11 +56,20 @@ pub enum NixFile {
     Services(PathBuf),
 }
 
-impl From<&NixFile> for PathBuf {
-    fn from(p: &NixFile) -> PathBuf {
-        match p {
-            NixFile::Shell(p) => p.to_path_buf(),
-            NixFile::Services(p) => p.to_path_buf(),
+impl NixFile {
+    /// Underlying `Path`.
+    pub fn as_path(&self) -> &Path {
+        match self {
+            Self::Shell(ref path) => path,
+            Self::Services(ref path) => path,
+        }
+    }
+
+    /// Display the underlying path
+    pub fn display(&self) -> std::path::Display {
+        match self {
+            Self::Shell(path) => path.display(),
+            Self::Services(path) => path.display(),
         }
     }
 }
@@ -72,7 +81,7 @@ impl slog::Value for NixFile {
         key: slog::Key,
         serializer: &mut dyn slog::Serializer,
     ) -> slog::Result {
-        serializer.emit_arguments(key, &format_args!("{}", PathBuf::from(self).display()))
+        serializer.emit_arguments(key, &format_args!("{}", self.as_path().display()))
     }
 }
 

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -534,7 +534,7 @@ mod tests {
             "--expr",
             "my-cool-expression",
         ]
-        .into_iter()
+        .iter()
         .map(OsStr::new)
         .collect();
         assert_eq!(exp, nix.command_arguments());
@@ -565,7 +565,7 @@ mod tests {
             "--",
             "/my-cool-file.nix",
         ]
-        .into_iter()
+        .iter()
         .map(OsStr::new)
         .collect();
         assert_eq!(exp2, nix2.command_arguments());

--- a/src/ops/daemon.rs
+++ b/src/ops/daemon.rs
@@ -17,7 +17,7 @@ pub fn main(opts: crate::cli::DaemonOptions) -> OpResult {
         },
     };
 
-    let (daemon, build_rx) = Daemon::new(extra_nix_options);
+    let (mut daemon, build_rx) = Daemon::new(extra_nix_options);
     let build_handle = std::thread::spawn(|| {
         for msg in build_rx {
             info!("build status"; "message" => ?msg);

--- a/src/ops/shell.rs
+++ b/src/ops/shell.rs
@@ -61,7 +61,9 @@ pub fn main(project: Project, opts: ShellOptions) -> OpResult {
                 .to_str()
                 .expect("lorri executable path not UTF-8 clean"),
             &shell,
-            &PathBuf::from(&project.nix_file)
+            project
+                .nix_file
+                .as_path()
                 .to_str()
                 .expect("Nix file path not UTF-8 clean"),
         ])

--- a/src/project.rs
+++ b/src/project.rs
@@ -36,7 +36,7 @@ impl Project {
     ) -> std::io::Result<Project> {
         let hash = format!(
             "{:x}",
-            md5::compute(PathBuf::from(&nix_file).as_os_str().as_bytes())
+            md5::compute(nix_file.as_path().as_os_str().as_bytes())
         );
         let project_gc_root = gc_root_dir.join(&hash).join("gc_root");
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -4,7 +4,8 @@ use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 
 /// Small wrapper that makes sure lorri sockets are handled correctly.
-pub struct SocketPath(PathBuf);
+#[derive(Clone)]
+pub struct SocketPath(pub PathBuf);
 
 /// Binding to the socket failed.
 #[derive(Debug)]
@@ -15,12 +16,6 @@ pub enum BindError {
     Io(std::io::Error),
     /// nix library I/O error (like Io)
     Unix(nix::Error),
-}
-
-impl From<BindError> for crate::ops::error::ExitError {
-    fn from(e: BindError) -> crate::ops::error::ExitError {
-        crate::ops::error::ExitError::temporary(format!("Bind error: {:?}", e))
-    }
 }
 
 impl From<std::io::Error> for BindError {

--- a/tests/daemon/main.rs
+++ b/tests/daemon/main.rs
@@ -29,7 +29,7 @@ pub fn start_job_with_ping() -> std::io::Result<()> {
     let gc_root_dir = tempdir.path().join("gc_root").to_path_buf();
 
     // The daemon knows how to build stuff
-    let (daemon, build_rx) = Daemon::new(NixOptions::empty());
+    let (mut daemon, build_rx) = Daemon::new(NixOptions::empty());
     let accept_handle = thread::spawn(move || {
         daemon
             .serve(socket_path, gc_root_dir, cas)

--- a/tests/shell/main.rs
+++ b/tests/shell/main.rs
@@ -35,10 +35,7 @@ fn loads_env() {
         .args(&[
             "shell",
             "--shell-file",
-            PathBuf::from(&project.nix_file)
-                .as_os_str()
-                .to_str()
-                .unwrap(),
+            project.nix_file.as_path().as_os_str().to_str().unwrap(),
         ])
         .current_dir(&tempdir)
         .output()


### PR DESCRIPTION
This is a rather bigger change than I hoped it would be, but I think I found a good solution for the issues many people have been having in https://github.com/target/lorri/issues/375.

Which is mainly that the thread pool was not re-throwing the call stack of the panicking inner thread, but just throwing its own panic, so `human-panic` would show the same error message for every panic (that the `dyn Any` returned by `thread_handle.join()` cannot print the actual data did not help).

I did a bit of refactoring before tackling the actual problem and wrote quite extensive commit messages, so best reviewed commit-by-commit.

I started using [commit markers](https://code.tvl.fyi/tree/docs/CONTRIBUTING.md#n35) to better distinguish refactor commits from actual feature commits, and it looks quite usable to me.