### PR TITLE
chore(ci): run on darwin too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ env:
   LORRI_NO_INSTALL_PANIC_HANDLER: absolutely
 jobs:
   rust:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -41,7 +44,10 @@ jobs:
       - name: CI check
         run: nix-shell --arg isDevelopmentShell false --run 'ci_check'
   nix-build_stable:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -63,7 +69,10 @@ jobs:
       - name: Self-upgrade
         run: lorri self-upgrade local $(pwd)
   nix-build_1909:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -79,7 +88,10 @@ jobs:
       - name: Build
         run: nix-build --arg nixpkgs ./nix/nixpkgs-1909.nix
   nix-shell:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -95,7 +107,10 @@ jobs:
       - name: Build
         run: nix-build -A allBuildInputs shell.nix
   overlay:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Followup to https://github.com/target/lorri/pull/436#issuecomment-651221145.

Next, I'd like to set up clippy and rustfmt to run on PRs. This would only happen on `ubuntu-latest`, because apparently, darwin can sometimes ship without `clippy`/`rustfmt` (see the failed CI on https://github.com/cole-h/lorri/pull/4 for examples of what happens when you try)?

cc @curiousleo 