### PR TITLE
release 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "lorri"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "atomicwrites 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -6,86 +6,86 @@ let inherit (lib.lists) fold;
 in
 rec {
   crates = cratesIO // rec {
-# lorri-1.1.0
+# lorri-1.1.1
 
-    crates.lorri."1.1.0" = deps: { features?(features_.lorri."1.1.0" deps {}) }: buildRustCrate {
+    crates.lorri."1.1.1" = deps: { features?(features_.lorri."1.1.1" deps {}) }: buildRustCrate {
       crateName = "lorri";
-      version = "1.1.0";
+      version = "1.1.1";
       authors = [ "Graham Christensen <graham.christensen@target.com>" ];
       edition = "2018";
       src = exclude [ ".git" "target" ] ./.;
       dependencies = mapFeatures features ([
-        (cratesIO.crates."atomicwrites"."${deps."lorri"."1.1.0"."atomicwrites"}" deps)
-        (cratesIO.crates."crossbeam_channel"."${deps."lorri"."1.1.0"."crossbeam_channel"}" deps)
-        (cratesIO.crates."directories"."${deps."lorri"."1.1.0"."directories"}" deps)
-        (cratesIO.crates."human_panic"."${deps."lorri"."1.1.0"."human_panic"}" deps)
-        (cratesIO.crates."lazy_static"."${deps."lorri"."1.1.0"."lazy_static"}" deps)
-        (cratesIO.crates."md5"."${deps."lorri"."1.1.0"."md5"}" deps)
-        (cratesIO.crates."nix"."${deps."lorri"."1.1.0"."nix"}" deps)
-        (cratesIO.crates."notify"."${deps."lorri"."1.1.0"."notify"}" deps)
-        (cratesIO.crates."proptest"."${deps."lorri"."1.1.0"."proptest"}" deps)
-        (cratesIO.crates."regex"."${deps."lorri"."1.1.0"."regex"}" deps)
-        (cratesIO.crates."serde"."${deps."lorri"."1.1.0"."serde"}" deps)
-        (cratesIO.crates."serde_derive"."${deps."lorri"."1.1.0"."serde_derive"}" deps)
-        (cratesIO.crates."serde_json"."${deps."lorri"."1.1.0"."serde_json"}" deps)
-        (cratesIO.crates."slog"."${deps."lorri"."1.1.0"."slog"}" deps)
-        (cratesIO.crates."slog_scope"."${deps."lorri"."1.1.0"."slog_scope"}" deps)
-        (cratesIO.crates."slog_term"."${deps."lorri"."1.1.0"."slog_term"}" deps)
-        (cratesIO.crates."structopt"."${deps."lorri"."1.1.0"."structopt"}" deps)
-        (cratesIO.crates."tempfile"."${deps."lorri"."1.1.0"."tempfile"}" deps)
-        (cratesIO.crates."varlink"."${deps."lorri"."1.1.0"."varlink"}" deps)
-        (cratesIO.crates."vec1"."${deps."lorri"."1.1.0"."vec1"}" deps)
+        (cratesIO.crates."atomicwrites"."${deps."lorri"."1.1.1"."atomicwrites"}" deps)
+        (cratesIO.crates."crossbeam_channel"."${deps."lorri"."1.1.1"."crossbeam_channel"}" deps)
+        (cratesIO.crates."directories"."${deps."lorri"."1.1.1"."directories"}" deps)
+        (cratesIO.crates."human_panic"."${deps."lorri"."1.1.1"."human_panic"}" deps)
+        (cratesIO.crates."lazy_static"."${deps."lorri"."1.1.1"."lazy_static"}" deps)
+        (cratesIO.crates."md5"."${deps."lorri"."1.1.1"."md5"}" deps)
+        (cratesIO.crates."nix"."${deps."lorri"."1.1.1"."nix"}" deps)
+        (cratesIO.crates."notify"."${deps."lorri"."1.1.1"."notify"}" deps)
+        (cratesIO.crates."proptest"."${deps."lorri"."1.1.1"."proptest"}" deps)
+        (cratesIO.crates."regex"."${deps."lorri"."1.1.1"."regex"}" deps)
+        (cratesIO.crates."serde"."${deps."lorri"."1.1.1"."serde"}" deps)
+        (cratesIO.crates."serde_derive"."${deps."lorri"."1.1.1"."serde_derive"}" deps)
+        (cratesIO.crates."serde_json"."${deps."lorri"."1.1.1"."serde_json"}" deps)
+        (cratesIO.crates."slog"."${deps."lorri"."1.1.1"."slog"}" deps)
+        (cratesIO.crates."slog_scope"."${deps."lorri"."1.1.1"."slog_scope"}" deps)
+        (cratesIO.crates."slog_term"."${deps."lorri"."1.1.1"."slog_term"}" deps)
+        (cratesIO.crates."structopt"."${deps."lorri"."1.1.1"."structopt"}" deps)
+        (cratesIO.crates."tempfile"."${deps."lorri"."1.1.1"."tempfile"}" deps)
+        (cratesIO.crates."varlink"."${deps."lorri"."1.1.1"."varlink"}" deps)
+        (cratesIO.crates."vec1"."${deps."lorri"."1.1.1"."vec1"}" deps)
       ]);
 
       buildDependencies = mapFeatures features ([
-        (cratesIO.crates."varlink_generator"."${deps."lorri"."1.1.0"."varlink_generator"}" deps)
+        (cratesIO.crates."varlink_generator"."${deps."lorri"."1.1.1"."varlink_generator"}" deps)
       ]);
     };
-    features_.lorri."1.1.0" = deps: f: updateFeatures f (rec {
-      atomicwrites."${deps.lorri."1.1.0".atomicwrites}".default = true;
-      crossbeam_channel."${deps.lorri."1.1.0".crossbeam_channel}".default = true;
-      directories."${deps.lorri."1.1.0".directories}".default = true;
-      human_panic."${deps.lorri."1.1.0".human_panic}".default = true;
-      lazy_static."${deps.lorri."1.1.0".lazy_static}".default = true;
-      lorri."1.1.0".default = (f.lorri."1.1.0".default or true);
-      md5."${deps.lorri."1.1.0".md5}".default = true;
-      nix."${deps.lorri."1.1.0".nix}".default = true;
-      notify."${deps.lorri."1.1.0".notify}".default = true;
-      proptest."${deps.lorri."1.1.0".proptest}".default = true;
-      regex."${deps.lorri."1.1.0".regex}".default = true;
-      serde."${deps.lorri."1.1.0".serde}".default = true;
-      serde_derive."${deps.lorri."1.1.0".serde_derive}".default = true;
-      serde_json."${deps.lorri."1.1.0".serde_json}".default = true;
-      slog."${deps.lorri."1.1.0".slog}".default = true;
-      slog_scope."${deps.lorri."1.1.0".slog_scope}".default = true;
-      slog_term."${deps.lorri."1.1.0".slog_term}".default = true;
-      structopt."${deps.lorri."1.1.0".structopt}".default = true;
-      tempfile."${deps.lorri."1.1.0".tempfile}".default = true;
-      varlink."${deps.lorri."1.1.0".varlink}".default = true;
-      varlink_generator."${deps.lorri."1.1.0".varlink_generator}".default = true;
-      vec1."${deps.lorri."1.1.0".vec1}".default = true;
+    features_.lorri."1.1.1" = deps: f: updateFeatures f (rec {
+      atomicwrites."${deps.lorri."1.1.1".atomicwrites}".default = true;
+      crossbeam_channel."${deps.lorri."1.1.1".crossbeam_channel}".default = true;
+      directories."${deps.lorri."1.1.1".directories}".default = true;
+      human_panic."${deps.lorri."1.1.1".human_panic}".default = true;
+      lazy_static."${deps.lorri."1.1.1".lazy_static}".default = true;
+      lorri."1.1.1".default = (f.lorri."1.1.1".default or true);
+      md5."${deps.lorri."1.1.1".md5}".default = true;
+      nix."${deps.lorri."1.1.1".nix}".default = true;
+      notify."${deps.lorri."1.1.1".notify}".default = true;
+      proptest."${deps.lorri."1.1.1".proptest}".default = true;
+      regex."${deps.lorri."1.1.1".regex}".default = true;
+      serde."${deps.lorri."1.1.1".serde}".default = true;
+      serde_derive."${deps.lorri."1.1.1".serde_derive}".default = true;
+      serde_json."${deps.lorri."1.1.1".serde_json}".default = true;
+      slog."${deps.lorri."1.1.1".slog}".default = true;
+      slog_scope."${deps.lorri."1.1.1".slog_scope}".default = true;
+      slog_term."${deps.lorri."1.1.1".slog_term}".default = true;
+      structopt."${deps.lorri."1.1.1".structopt}".default = true;
+      tempfile."${deps.lorri."1.1.1".tempfile}".default = true;
+      varlink."${deps.lorri."1.1.1".varlink}".default = true;
+      varlink_generator."${deps.lorri."1.1.1".varlink_generator}".default = true;
+      vec1."${deps.lorri."1.1.1".vec1}".default = true;
     }) [
-      (cratesIO.features_.atomicwrites."${deps."lorri"."1.1.0"."atomicwrites"}" deps)
-      (cratesIO.features_.crossbeam_channel."${deps."lorri"."1.1.0"."crossbeam_channel"}" deps)
-      (cratesIO.features_.directories."${deps."lorri"."1.1.0"."directories"}" deps)
-      (cratesIO.features_.human_panic."${deps."lorri"."1.1.0"."human_panic"}" deps)
-      (cratesIO.features_.lazy_static."${deps."lorri"."1.1.0"."lazy_static"}" deps)
-      (cratesIO.features_.md5."${deps."lorri"."1.1.0"."md5"}" deps)
-      (cratesIO.features_.nix."${deps."lorri"."1.1.0"."nix"}" deps)
-      (cratesIO.features_.notify."${deps."lorri"."1.1.0"."notify"}" deps)
-      (cratesIO.features_.proptest."${deps."lorri"."1.1.0"."proptest"}" deps)
-      (cratesIO.features_.regex."${deps."lorri"."1.1.0"."regex"}" deps)
-      (cratesIO.features_.serde."${deps."lorri"."1.1.0"."serde"}" deps)
-      (cratesIO.features_.serde_derive."${deps."lorri"."1.1.0"."serde_derive"}" deps)
-      (cratesIO.features_.serde_json."${deps."lorri"."1.1.0"."serde_json"}" deps)
-      (cratesIO.features_.slog."${deps."lorri"."1.1.0"."slog"}" deps)
-      (cratesIO.features_.slog_scope."${deps."lorri"."1.1.0"."slog_scope"}" deps)
-      (cratesIO.features_.slog_term."${deps."lorri"."1.1.0"."slog_term"}" deps)
-      (cratesIO.features_.structopt."${deps."lorri"."1.1.0"."structopt"}" deps)
-      (cratesIO.features_.tempfile."${deps."lorri"."1.1.0"."tempfile"}" deps)
-      (cratesIO.features_.varlink."${deps."lorri"."1.1.0"."varlink"}" deps)
-      (cratesIO.features_.vec1."${deps."lorri"."1.1.0"."vec1"}" deps)
-      (cratesIO.features_.varlink_generator."${deps."lorri"."1.1.0"."varlink_generator"}" deps)
+      (cratesIO.features_.atomicwrites."${deps."lorri"."1.1.1"."atomicwrites"}" deps)
+      (cratesIO.features_.crossbeam_channel."${deps."lorri"."1.1.1"."crossbeam_channel"}" deps)
+      (cratesIO.features_.directories."${deps."lorri"."1.1.1"."directories"}" deps)
+      (cratesIO.features_.human_panic."${deps."lorri"."1.1.1"."human_panic"}" deps)
+      (cratesIO.features_.lazy_static."${deps."lorri"."1.1.1"."lazy_static"}" deps)
+      (cratesIO.features_.md5."${deps."lorri"."1.1.1"."md5"}" deps)
+      (cratesIO.features_.nix."${deps."lorri"."1.1.1"."nix"}" deps)
+      (cratesIO.features_.notify."${deps."lorri"."1.1.1"."notify"}" deps)
+      (cratesIO.features_.proptest."${deps."lorri"."1.1.1"."proptest"}" deps)
+      (cratesIO.features_.regex."${deps."lorri"."1.1.1"."regex"}" deps)
+      (cratesIO.features_.serde."${deps."lorri"."1.1.1"."serde"}" deps)
+      (cratesIO.features_.serde_derive."${deps."lorri"."1.1.1"."serde_derive"}" deps)
+      (cratesIO.features_.serde_json."${deps."lorri"."1.1.1"."serde_json"}" deps)
+      (cratesIO.features_.slog."${deps."lorri"."1.1.1"."slog"}" deps)
+      (cratesIO.features_.slog_scope."${deps."lorri"."1.1.1"."slog_scope"}" deps)
+      (cratesIO.features_.slog_term."${deps."lorri"."1.1.1"."slog_term"}" deps)
+      (cratesIO.features_.structopt."${deps."lorri"."1.1.1"."structopt"}" deps)
+      (cratesIO.features_.tempfile."${deps."lorri"."1.1.1"."tempfile"}" deps)
+      (cratesIO.features_.varlink."${deps."lorri"."1.1.1"."varlink"}" deps)
+      (cratesIO.features_.vec1."${deps."lorri"."1.1.1"."vec1"}" deps)
+      (cratesIO.features_.varlink_generator."${deps."lorri"."1.1.1"."varlink_generator"}" deps)
     ];
 
 
@@ -93,7 +93,7 @@ rec {
 
   };
 
-  lorri = crates.crates.lorri."1.1.0" deps;
+  lorri = crates.crates.lorri."1.1.1" deps;
   __all = [ (lorri {}) ];
   deps.aho_corasick."0.7.12" = {
     memchr = "2.3.3";
@@ -257,7 +257,7 @@ rec {
   deps.log."0.4.8" = {
     cfg_if = "0.1.10";
   };
-  deps.lorri."1.1.0" = {
+  deps.lorri."1.1.1" = {
     atomicwrites = "0.2.5";
     crossbeam_channel = "0.3.9";
     directories = "1.0.2";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "lorri"
 # lorri uses a MAJOR.MINOR versioning scheme, see MAINTAINERS.md for details.
 # Cargo requires MAJOR.MINOR.PATCH. So we translate lorri's versioning scheme
 # to MAJOR.MINOR.0, i.e. the PATCH part is always zero.
-version = "1.1.0" # Format: MAJOR.MINOR.0
+version = "1.1.1" # Format: MAJOR.MINOR.0
 authors = [
   "Graham Christensen <graham.christensen@target.com>",
 ]

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,8 +2,8 @@
 
 ## Versioning scheme
 
-The versioning scheme for lorri is `MAJOR.MINOR`, where `MAJOR` and `MINOR` are
-non-negative integers without leading zeroes.
+The versioning scheme for lorri is `MAJOR.MINOR.PATCH`, where `MAJOR`, `MINOR` and `PATCH`
+are non-negative integers without leading zeroes.
 
 ### Terminology
 
@@ -35,7 +35,11 @@ For example: it's a major release if since the last released version,
   now fails to build with lorri, unless the previous behaviour is considered a
   bug.
 
-In any other case, increment the `MINOR` version.
+In any other case when a feature changes, increment the `MINOR` version.
+
+If there is a bug fix or a security fix that does not change the interface,
+increment the `PATCH` version. Also if there is a documentation improvement
+that should get its own release.
 
 (\*) The exception to this rule is `lorri direnv`: it is an external command
 with machine-readable output whose output may change between minor releases,

--- a/release.nix
+++ b/release.nix
@@ -6,6 +6,12 @@
     # Find the current version number with `git log --pretty=%h | wc -l`
     entries = [
       {
+        version = 626;
+        changes = ''
+          Added manpage for lorri(1).
+        '';
+      }
+      {
         version = 581;
         changes = ''
           Fix `lorri shell` for zsh. ZDOTDIR is loaded correctly.


### PR DESCRIPTION
I’d like to push the manpage change to nixpkgs.

The MAINTAINERS says we don’t use the patch version field, but I don’t think it’s wise to bump the minor version for an update in documentation, so I’d use the patch field in this case.