### PR TITLE
fix(ci): only run CI on push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [ "**" ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "**" ]
 env:


### PR DESCRIPTION
Github actions is super unoptimized, so if you push a branch to the
repo and then create a PR for it, it won’t recognize that it is
building exactly the same commit and schedule the whole matrix again.

Since there is a restriction on how many builders we can
use (especially BSD light builders), this increases our CI build time
considerably.

So let’s restrict to master.

Based on the reply in
https://twitter.com/basile_henry/status/1288724098319814657
