### PR TITLE
CI: dedup and trim

### DIFF
--- a/.github/workflows/ci.nix
+++ b/.github/workflows/ci.nix
@@ -107,23 +107,6 @@ let
       };
     };
 
-    nix-shell = { runs-on }: {
-      name = "nix-shell-${runs-on}";
-      value = {
-        name = "nix-shell allBuildInputs (${runs-on})";
-        inherit runs-on;
-        steps = [
-          (checkout {})
-          setup-nix
-          setup-cachix
-          {
-            name = "Build";
-            run = "nix-build -A allBuildInputs shell.nix";
-          }
-        ];
-      };
-    };
-
     overlay = { runs-on }: {
       name = "overlay-${runs-on}";
       value = {
@@ -162,8 +145,6 @@ let
         (builds.stable { runs-on = githubRunners.macos; })
         (builds.nixos-19_09 { runs-on = githubRunners.ubuntu; })
         (builds.nixos-19_09 { runs-on = githubRunners.macos; })
-        (builds.nix-shell { runs-on = githubRunners.ubuntu; })
-        (builds.nix-shell { runs-on = githubRunners.macos; })
         (builds.overlay { runs-on = githubRunners.ubuntu; })
         (builds.overlay { runs-on = githubRunners.macos; })
       ];

--- a/.github/workflows/ci.nix
+++ b/.github/workflows/ci.nix
@@ -1,5 +1,12 @@
 { pkgs ? import ../../nix/nixpkgs-stable.nix }:
 let
+  setup-nix = {
+    name = "Nix";
+    uses = "cachix/install-nix-action@v9";
+    "with" = {
+      skip_adding_nixpkgs_channel = true;
+    };
+  };
   setup-cachix = {
     name = "Cachix";
     uses = "cachix/cachix-action@v6";
@@ -24,13 +31,7 @@ let
             name = "Checkout";
             uses = "actions/checkout@v2";
           }
-          {
-            name = "Nix";
-            uses = "cachix/install-nix-action@v9";
-            "with" = {
-              skip_adding_nixpkgs_channel = true;
-            };
-          }
+          setup-nix
           setup-cachix
           {
             name = "Cache cargo registry";
@@ -77,13 +78,7 @@ let
               fetch-depth = 0;
             };
           }
-          {
-            name = "Nix";
-            uses = "cachix/install-nix-action@v9";
-            "with" = {
-              skip_adding_nixpkgs_channel = true;
-            };
-          }
+          setup-nix
           setup-cachix
           { name = "Build"; run = "nix-build"; }
           {
@@ -104,13 +99,7 @@ let
             name = "Checkout";
             uses = "actions/checkout@v2";
           }
-          {
-            name = "Nix";
-            uses = "cachix/install-nix-action@v9";
-            "with" = {
-              skip_adding_nixpkgs_channel = true;
-            };
-          }
+          setup-nix
           setup-cachix
           {
             name = "Build";
@@ -126,13 +115,7 @@ let
             name = "Checkout";
             uses = "actions/checkout@v2";
           }
-          {
-            name = "Nix";
-            uses = "cachix/install-nix-action@v9";
-            "with" = {
-              skip_adding_nixpkgs_channel = true;
-            };
-          }
+          setup-nix
           setup-cachix
           {
             name = "Build";
@@ -148,13 +131,7 @@ let
             name = "Checkout";
             uses = "actions/checkout@v2";
           }
-          {
-            name = "Nix";
-            uses = "cachix/install-nix-action@v9";
-            "with" = {
-              skip_adding_nixpkgs_channel = true;
-            };
-          }
+          setup-nix
           setup-cachix
           {
             name = "Build w/ overlay (19.09)";

--- a/.github/workflows/ci.nix
+++ b/.github/workflows/ci.nix
@@ -23,32 +23,18 @@ let
     };
   };
 
-  rust-cache = [
-    {
-      name = "Cache cargo registry";
-      uses = "actions/cache@v1";
-      "with" = {
-        key = "\${{ runner.os }}-cargo-registry-\${{ hashFiles('**/Cargo.lock') }}";
-        path = "~/.cargo/registry";
-      };
-    }
-    {
-      name = "Cache cargo index";
-      uses = "actions/cache@v1";
-      "with" = {
-        key = "\${{ runner.os }}-cargo-index-\${{ hashFiles('**/Cargo.lock') }}";
-        path = "~/.cargo/git";
-      };
-    }
-    {
-      name = "Cache cargo build";
-      uses = "actions/cache@v1";
-      "with" = {
-        key = "\${{ runner.os }}-cargo-build-target-\${{ hashFiles('**/Cargo.lock') }}";
-        path = "target";
-      };
-    }
-  ];
+  rust-cache = {
+    name = "Cache cargo registry";
+    uses = "actions/cache@v2";
+    "with" = {
+      path = ''
+        "~/.cargo/registry"
+        "~/.cargo/git"
+        "target"
+      '';
+      key = "\${{ runner.os }}-cargo-registry-\${{ hashFiles('**/Cargo.lock') }}";
+    };
+  };
 
   githubRunners = {
     ubuntu = "ubuntu-latest";
@@ -65,7 +51,7 @@ let
           (checkout {})
           setup-nix
           setup-cachix
-        ] ++ rust-cache ++ [
+          rust-cache
           {
             name = "CI check";
             run = "nix-shell --arg isDevelopmentShell false --run 'ci_check'";
@@ -88,7 +74,10 @@ let
           )
           setup-nix
           setup-cachix
-          { name = "Build"; run = "nix-build"; }
+          {
+            name = "Build";
+            run = "nix-build";
+          }
           {
             name = "Install";
             run = "nix-env -i ./result";

--- a/.github/workflows/ci.nix
+++ b/.github/workflows/ci.nix
@@ -1,6 +1,5 @@
+{ pkgs ? import ../../nix/nixpkgs-stable.nix }:
 let
-  pkgs = import ../../nix/nixpkgs-stable.nix;
-
   config = {
     name = "CI";
     on = {

--- a/.github/workflows/ci.nix
+++ b/.github/workflows/ci.nix
@@ -63,10 +63,6 @@ let
             };
           }
           {
-            name = "Shell (cache inputs)";
-            run = "nix-shell";
-          }
-          {
             name = "CI check";
             run = "nix-shell --arg isDevelopmentShell false --run 'ci_check'";
           }

--- a/.github/workflows/ci.nix
+++ b/.github/workflows/ci.nix
@@ -23,6 +23,33 @@ let
     };
   };
 
+  rust-cache = [
+    {
+      name = "Cache cargo registry";
+      uses = "actions/cache@v1";
+      "with" = {
+        key = "\${{ runner.os }}-cargo-registry-\${{ hashFiles('**/Cargo.lock') }}";
+        path = "~/.cargo/registry";
+      };
+    }
+    {
+      name = "Cache cargo index";
+      uses = "actions/cache@v1";
+      "with" = {
+        key = "\${{ runner.os }}-cargo-index-\${{ hashFiles('**/Cargo.lock') }}";
+        path = "~/.cargo/git";
+      };
+    }
+    {
+      name = "Cache cargo build";
+      uses = "actions/cache@v1";
+      "with" = {
+        key = "\${{ runner.os }}-cargo-build-target-\${{ hashFiles('**/Cargo.lock') }}";
+        path = "target";
+      };
+    }
+  ];
+
   githubRunners = {
     ubuntu = "ubuntu-latest";
     macos = "macos-latest";
@@ -38,30 +65,7 @@ let
           (checkout {})
           setup-nix
           setup-cachix
-          {
-            name = "Cache cargo registry";
-            uses = "actions/cache@v1";
-            "with" = {
-              key = "\${{ runner.os }}-cargo-registry-\${{ hashFiles('**/Cargo.lock') }}";
-              path = "~/.cargo/registry";
-            };
-          }
-          {
-            name = "Cache cargo index";
-            uses = "actions/cache@v1";
-            "with" = {
-              key = "\${{ runner.os }}-cargo-index-\${{ hashFiles('**/Cargo.lock') }}";
-              path = "~/.cargo/git";
-            };
-          }
-          {
-            name = "Cache cargo build";
-            uses = "actions/cache@v1";
-            "with" = {
-              key = "\${{ runner.os }}-cargo-build-target-\${{ hashFiles('**/Cargo.lock') }}";
-              path = "target";
-            };
-          }
+        ] ++ rust-cache ++ [
           {
             name = "CI check";
             run = "nix-shell --arg isDevelopmentShell false --run 'ci_check'";

--- a/.github/workflows/ci.nix
+++ b/.github/workflows/ci.nix
@@ -13,85 +13,54 @@ let
         steps = [
           {
             name = "Checkout";
-            run = null;
             uses = "actions/checkout@v2";
-            "with" = null;
           }
           {
             name = "Nix";
-            run = null;
             uses = "cachix/install-nix-action@v9";
             "with" = {
-              key = null;
-              name = null;
-              path = null;
-              signingKey = null;
-              skipPush = null;
               skip_adding_nixpkgs_channel = true;
             };
           }
           {
             name = "Cachix";
-            run = null;
             uses = "cachix/cachix-action@v6";
             "with" = {
-              key = null;
               name = "lorri-test";
-              path = null;
               signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
-              skip_adding_nixpkgs_channel = null;
             };
           }
           {
             name = "Cache cargo registry";
-            run = null;
             uses = "actions/cache@v1";
             "with" = {
               key = "\${{ runner.os }}-cargo-registry-\${{ hashFiles('**/Cargo.lock') }}";
-              name = null;
               path = "~/.cargo/registry";
-              signingKey = null;
-              skipPush = null;
-              skip_adding_nixpkgs_channel = null;
             };
           }
           {
             name = "Cache cargo index";
-            run = null;
             uses = "actions/cache@v1";
             "with" = {
               key = "\${{ runner.os }}-cargo-index-\${{ hashFiles('**/Cargo.lock') }}";
-              name = null;
               path = "~/.cargo/git";
-              signingKey = null;
-              skipPush = null;
-              skip_adding_nixpkgs_channel = null;
             };
           }
           {
             name = "Cache cargo build";
-            run = null;
             uses = "actions/cache@v1";
             "with" = {
               key = "\${{ runner.os }}-cargo-build-target-\${{ hashFiles('**/Cargo.lock') }}";
-              name = null;
               path = "target";
-              signingKey = null;
-              skipPush = null;
-              skip_adding_nixpkgs_channel = null;
             };
           }
           {
             name = "Shell (cache inputs)";
             run = "nix-shell";
-            uses = null;
-            "with" = null;
           }
           {
             name = "CI check";
             run = "nix-shell --arg isDevelopmentShell false --run 'ci_check'";
-            uses = null;
-            "with" = null;
           }
         ];
         strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
@@ -101,49 +70,34 @@ let
         steps = [
           {
             name = "Checkout";
-            run = null;
             uses = "actions/checkout@v2";
             "with" = {
               fetch-depth = 0;
-              name = null;
-              signingKey = null;
-              skip_adding_nixpkgs_channel = null;
             };
           }
           {
             name = "Nix";
-            run = null;
             uses = "cachix/install-nix-action@v9";
             "with" = {
-              fetch-depth = null;
-              name = null;
-              signingKey = null;
               skip_adding_nixpkgs_channel = true;
             };
           }
           {
             name = "Cachix";
-            run = null;
             uses = "cachix/cachix-action@v6";
             "with" = {
-              fetch-depth = null;
               name = "lorri-test";
               signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
-              skip_adding_nixpkgs_channel = null;
             };
           }
-          { name = "Build"; run = "nix-build"; uses = null; "with" = null; }
+          { name = "Build"; run = "nix-build"; }
           {
             name = "Install";
             run = "nix-env -i ./result";
-            uses = null;
-            "with" = null;
           }
           {
             name = "Self-upgrade";
             run = "lorri self-upgrade local \$(pwd)";
-            uses = null;
-            "with" = null;
           }
         ];
         strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
@@ -153,35 +107,26 @@ let
         steps = [
           {
             name = "Checkout";
-            run = null;
             uses = "actions/checkout@v2";
-            "with" = null;
           }
           {
             name = "Nix";
-            run = null;
             uses = "cachix/install-nix-action@v9";
             "with" = {
-              name = null;
-              signingKey = null;
               skip_adding_nixpkgs_channel = true;
             };
           }
           {
             name = "Cachix";
-            run = null;
             uses = "cachix/cachix-action@v6";
             "with" = {
               name = "lorri-test";
               signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
-              skip_adding_nixpkgs_channel = null;
             };
           }
           {
             name = "Build";
             run = "nix-build --arg nixpkgs ./nix/nixpkgs-1909.nix";
-            uses = null;
-            "with" = null;
           }
         ];
         strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
@@ -191,35 +136,26 @@ let
         steps = [
           {
             name = "Checkout";
-            run = null;
             uses = "actions/checkout@v2";
-            "with" = null;
           }
           {
             name = "Nix";
-            run = null;
             uses = "cachix/install-nix-action@v9";
             "with" = {
-              name = null;
-              signingKey = null;
               skip_adding_nixpkgs_channel = true;
             };
           }
           {
             name = "Cachix";
-            run = null;
             uses = "cachix/cachix-action@v6";
             "with" = {
               name = "lorri-test";
               signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
-              skip_adding_nixpkgs_channel = null;
             };
           }
           {
             name = "Build";
             run = "nix-build -A allBuildInputs shell.nix";
-            uses = null;
-            "with" = null;
           }
         ];
         strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
@@ -229,41 +165,30 @@ let
         steps = [
           {
             name = "Checkout";
-            run = null;
             uses = "actions/checkout@v2";
-            "with" = null;
           }
           {
             name = "Nix";
-            run = null;
             uses = "cachix/install-nix-action@v9";
             "with" = {
-              name = null;
-              signingKey = null;
               skip_adding_nixpkgs_channel = true;
             };
           }
           {
             name = "Cachix";
-            run = null;
             uses = "cachix/cachix-action@v6";
             "with" = {
               name = "lorri-test";
               signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
-              skip_adding_nixpkgs_channel = null;
             };
           }
           {
             name = "Build w/ overlay (19.09)";
             run = "nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-1909.json";
-            uses = null;
-            "with" = null;
           }
           {
             name = "Build w/ overlay (stable)";
             run = "nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-stable.json";
-            uses = null;
-            "with" = null;
           }
         ];
         strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };

--- a/.github/workflows/ci.nix
+++ b/.github/workflows/ci.nix
@@ -23,6 +23,135 @@ let
     };
   };
 
+  builds = {
+    rust = {
+      name = "rust";
+      value = {
+        runs-on = "\${{ matrix.os }}";
+        steps = [
+          (checkout {})
+          setup-nix
+          setup-cachix
+          {
+            name = "Cache cargo registry";
+            uses = "actions/cache@v1";
+            "with" = {
+              key = "\${{ runner.os }}-cargo-registry-\${{ hashFiles('**/Cargo.lock') }}";
+              path = "~/.cargo/registry";
+            };
+          }
+          {
+            name = "Cache cargo index";
+            uses = "actions/cache@v1";
+            "with" = {
+              key = "\${{ runner.os }}-cargo-index-\${{ hashFiles('**/Cargo.lock') }}";
+              path = "~/.cargo/git";
+            };
+          }
+          {
+            name = "Cache cargo build";
+            uses = "actions/cache@v1";
+            "with" = {
+              key = "\${{ runner.os }}-cargo-build-target-\${{ hashFiles('**/Cargo.lock') }}";
+              path = "target";
+            };
+          }
+          {
+            name = "Shell (cache inputs)";
+            run = "nix-shell";
+          }
+          {
+            name = "CI check";
+            run = "nix-shell --arg isDevelopmentShell false --run 'ci_check'";
+          }
+        ];
+        strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
+      };
+    };
+
+    stable = {
+      name = "nix-build_stable";
+      value = {
+        runs-on = "\${{ matrix.os }}";
+        steps = [
+          (
+            checkout {
+              # required for lorri self-upgrade local
+              fetch-depth = 0;
+            }
+          )
+          setup-nix
+          setup-cachix
+          { name = "Build"; run = "nix-build"; }
+          {
+            name = "Install";
+            run = "nix-env -i ./result";
+          }
+          {
+            name = "Self-upgrade";
+            run = "lorri self-upgrade local \$(pwd)";
+          }
+        ];
+        strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
+      };
+    };
+
+    nixos-19_09 = {
+      name = "nix-build_1909";
+      value = {
+        runs-on = "\${{ matrix.os }}";
+        steps = [
+          (checkout {})
+          setup-nix
+          setup-cachix
+          {
+            name = "Build";
+            run = "nix-build --arg nixpkgs ./nix/nixpkgs-1909.nix";
+          }
+        ];
+        strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
+      };
+    };
+
+    nix-shell = {
+      name = "nix-shell";
+      value = {
+        runs-on = "\${{ matrix.os }}";
+        steps = [
+          (checkout {})
+          setup-nix
+          setup-cachix
+          {
+            name = "Build";
+            run = "nix-build -A allBuildInputs shell.nix";
+          }
+        ];
+        strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
+      };
+    };
+
+    overlay = {
+      name = "overlay";
+      value = {
+        runs-on = "\${{ matrix.os }}";
+        steps = [
+          (checkout {})
+          setup-nix
+          setup-cachix
+          {
+            name = "Build w/ overlay (19.09)";
+            run = "nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-1909.json";
+          }
+          {
+            name = "Build w/ overlay (stable)";
+            run = "nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-stable.json";
+          }
+        ];
+        strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
+      };
+    };
+  };
+
   config = {
     name = "CI";
     on = {
@@ -30,130 +159,15 @@ let
       push = { branches = [ "master" ]; };
     };
     env = { LORRI_NO_INSTALL_PANIC_HANDLER = "absolutely"; };
-    jobs = builtins.listToAttrs [
-      {
-        name = "rust";
-        value = {
-          runs-on = "\${{ matrix.os }}";
-          steps = [
-            (checkout {})
-            setup-nix
-            setup-cachix
-            {
-              name = "Cache cargo registry";
-              uses = "actions/cache@v1";
-              "with" = {
-                key = "\${{ runner.os }}-cargo-registry-\${{ hashFiles('**/Cargo.lock') }}";
-                path = "~/.cargo/registry";
-              };
-            }
-            {
-              name = "Cache cargo index";
-              uses = "actions/cache@v1";
-              "with" = {
-                key = "\${{ runner.os }}-cargo-index-\${{ hashFiles('**/Cargo.lock') }}";
-                path = "~/.cargo/git";
-              };
-            }
-            {
-              name = "Cache cargo build";
-              uses = "actions/cache@v1";
-              "with" = {
-                key = "\${{ runner.os }}-cargo-build-target-\${{ hashFiles('**/Cargo.lock') }}";
-                path = "target";
-              };
-            }
-            {
-              name = "Shell (cache inputs)";
-              run = "nix-shell";
-            }
-            {
-              name = "CI check";
-              run = "nix-shell --arg isDevelopmentShell false --run 'ci_check'";
-            }
-          ];
-          strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
-        };
-      }
-      {
-        name = "nix-build_stable";
-        value = {
-          runs-on = "\${{ matrix.os }}";
-          steps = [
-            (
-              checkout {
-                # required for lorri self-upgrade local
-                fetch-depth = 0;
-              }
-            )
-            setup-nix
-            setup-cachix
-            { name = "Build"; run = "nix-build"; }
-            {
-              name = "Install";
-              run = "nix-env -i ./result";
-            }
-            {
-              name = "Self-upgrade";
-              run = "lorri self-upgrade local \$(pwd)";
-            }
-          ];
-          strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
-        };
-      }
-      {
-        name = "nix-build_1909";
-        value = {
-          runs-on = "\${{ matrix.os }}";
-          steps = [
-            (checkout {})
-            setup-nix
-            setup-cachix
-            {
-              name = "Build";
-              run = "nix-build --arg nixpkgs ./nix/nixpkgs-1909.nix";
-            }
-          ];
-          strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
-        };
-      }
-      {
-        name = "nix-shell";
-        value = {
-          runs-on = "\${{ matrix.os }}";
-          steps = [
-            (checkout {})
-            setup-nix
-            setup-cachix
-            {
-              name = "Build";
-              run = "nix-build -A allBuildInputs shell.nix";
-            }
-          ];
-          strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
-        };
-      }
-      {
-        name = "overlay";
-        value = {
-          runs-on = "\${{ matrix.os }}";
-          steps = [
-            (checkout {})
-            setup-nix
-            setup-cachix
-            {
-              name = "Build w/ overlay (19.09)";
-              run = "nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-1909.json";
-            }
-            {
-              name = "Build w/ overlay (stable)";
-              run = "nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-stable.json";
-            }
-          ];
-          strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
-        };
-      }
-    ];
+
+    jobs = builtins.listToAttrs
+      [
+        builds.rust
+        builds.stable
+        builds.nixos-19_09
+        builds.nix-shell
+        builds.overlay
+      ];
   };
 
   yaml = pkgs.runCommand "ci.yml" {

--- a/.github/workflows/ci.nix
+++ b/.github/workflows/ci.nix
@@ -1,5 +1,12 @@
 { pkgs ? import ../../nix/nixpkgs-stable.nix }:
 let
+  checkout = { fetch-depth ? null }: {
+    name = "Checkout";
+    uses = "actions/checkout@v2";
+    "with" = {
+      inherit fetch-depth;
+    };
+  };
   setup-nix = {
     name = "Nix";
     uses = "cachix/install-nix-action@v9";
@@ -27,10 +34,7 @@ let
       rust = {
         runs-on = "\${{ matrix.os }}";
         steps = [
-          {
-            name = "Checkout";
-            uses = "actions/checkout@v2";
-          }
+          (checkout {})
           setup-nix
           setup-cachix
           {
@@ -71,13 +75,12 @@ let
       nix-build_stable = {
         runs-on = "\${{ matrix.os }}";
         steps = [
-          {
-            name = "Checkout";
-            uses = "actions/checkout@v2";
-            "with" = {
+          (
+            checkout {
+              # required for lorri self-upgrade local
               fetch-depth = 0;
-            };
-          }
+            }
+          )
           setup-nix
           setup-cachix
           { name = "Build"; run = "nix-build"; }
@@ -95,10 +98,7 @@ let
       nix-build_1909 = {
         runs-on = "\${{ matrix.os }}";
         steps = [
-          {
-            name = "Checkout";
-            uses = "actions/checkout@v2";
-          }
+          (checkout {})
           setup-nix
           setup-cachix
           {
@@ -111,10 +111,7 @@ let
       nix-shell = {
         runs-on = "\${{ matrix.os }}";
         steps = [
-          {
-            name = "Checkout";
-            uses = "actions/checkout@v2";
-          }
+          (checkout {})
           setup-nix
           setup-cachix
           {
@@ -127,10 +124,7 @@ let
       overlay = {
         runs-on = "\${{ matrix.os }}";
         steps = [
-          {
-            name = "Checkout";
-            uses = "actions/checkout@v2";
-          }
+          (checkout {})
           setup-nix
           setup-cachix
           {

--- a/.github/workflows/ci.nix
+++ b/.github/workflows/ci.nix
@@ -1,5 +1,14 @@
 { pkgs ? import ../../nix/nixpkgs-stable.nix }:
 let
+  setup-cachix = {
+    name = "Cachix";
+    uses = "cachix/cachix-action@v6";
+    "with" = {
+      name = "lorri-test";
+      signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
+    };
+  };
+
   config = {
     name = "CI";
     on = {
@@ -22,14 +31,7 @@ let
               skip_adding_nixpkgs_channel = true;
             };
           }
-          {
-            name = "Cachix";
-            uses = "cachix/cachix-action@v6";
-            "with" = {
-              name = "lorri-test";
-              signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
-            };
-          }
+          setup-cachix
           {
             name = "Cache cargo registry";
             uses = "actions/cache@v1";
@@ -82,14 +84,7 @@ let
               skip_adding_nixpkgs_channel = true;
             };
           }
-          {
-            name = "Cachix";
-            uses = "cachix/cachix-action@v6";
-            "with" = {
-              name = "lorri-test";
-              signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
-            };
-          }
+          setup-cachix
           { name = "Build"; run = "nix-build"; }
           {
             name = "Install";
@@ -116,14 +111,7 @@ let
               skip_adding_nixpkgs_channel = true;
             };
           }
-          {
-            name = "Cachix";
-            uses = "cachix/cachix-action@v6";
-            "with" = {
-              name = "lorri-test";
-              signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
-            };
-          }
+          setup-cachix
           {
             name = "Build";
             run = "nix-build --arg nixpkgs ./nix/nixpkgs-1909.nix";
@@ -145,14 +133,7 @@ let
               skip_adding_nixpkgs_channel = true;
             };
           }
-          {
-            name = "Cachix";
-            uses = "cachix/cachix-action@v6";
-            "with" = {
-              name = "lorri-test";
-              signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
-            };
-          }
+          setup-cachix
           {
             name = "Build";
             run = "nix-build -A allBuildInputs shell.nix";
@@ -174,14 +155,7 @@ let
               skip_adding_nixpkgs_channel = true;
             };
           }
-          {
-            name = "Cachix";
-            uses = "cachix/cachix-action@v6";
-            "with" = {
-              name = "lorri-test";
-              signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
-            };
-          }
+          setup-cachix
           {
             name = "Build w/ overlay (19.09)";
             run = "nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-1909.json";

--- a/.github/workflows/ci.nix
+++ b/.github/workflows/ci.nix
@@ -1,0 +1,291 @@
+let
+  pkgs = import ../../nix/nixpkgs-stable.nix;
+
+  config = {
+    name = "CI";
+    on = {
+      pull_request = { branches = [ "**" ]; };
+      push = { branches = [ "master" ]; };
+    };
+    env = { LORRI_NO_INSTALL_PANIC_HANDLER = "absolutely"; };
+    jobs = {
+      rust = {
+        runs-on = "\${{ matrix.os }}";
+        steps = [
+          {
+            name = "Checkout";
+            run = null;
+            uses = "actions/checkout@v2";
+            "with" = null;
+          }
+          {
+            name = "Nix";
+            run = null;
+            uses = "cachix/install-nix-action@v9";
+            "with" = {
+              key = null;
+              name = null;
+              path = null;
+              signingKey = null;
+              skipPush = null;
+              skip_adding_nixpkgs_channel = true;
+            };
+          }
+          {
+            name = "Cachix";
+            run = null;
+            uses = "cachix/cachix-action@v6";
+            "with" = {
+              key = null;
+              name = "lorri-test";
+              path = null;
+              signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
+              skip_adding_nixpkgs_channel = null;
+            };
+          }
+          {
+            name = "Cache cargo registry";
+            run = null;
+            uses = "actions/cache@v1";
+            "with" = {
+              key = "\${{ runner.os }}-cargo-registry-\${{ hashFiles('**/Cargo.lock') }}";
+              name = null;
+              path = "~/.cargo/registry";
+              signingKey = null;
+              skipPush = null;
+              skip_adding_nixpkgs_channel = null;
+            };
+          }
+          {
+            name = "Cache cargo index";
+            run = null;
+            uses = "actions/cache@v1";
+            "with" = {
+              key = "\${{ runner.os }}-cargo-index-\${{ hashFiles('**/Cargo.lock') }}";
+              name = null;
+              path = "~/.cargo/git";
+              signingKey = null;
+              skipPush = null;
+              skip_adding_nixpkgs_channel = null;
+            };
+          }
+          {
+            name = "Cache cargo build";
+            run = null;
+            uses = "actions/cache@v1";
+            "with" = {
+              key = "\${{ runner.os }}-cargo-build-target-\${{ hashFiles('**/Cargo.lock') }}";
+              name = null;
+              path = "target";
+              signingKey = null;
+              skipPush = null;
+              skip_adding_nixpkgs_channel = null;
+            };
+          }
+          {
+            name = "Shell (cache inputs)";
+            run = "nix-shell";
+            uses = null;
+            "with" = null;
+          }
+          {
+            name = "CI check";
+            run = "nix-shell --arg isDevelopmentShell false --run 'ci_check'";
+            uses = null;
+            "with" = null;
+          }
+        ];
+        strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
+      };
+      nix-build_stable = {
+        runs-on = "\${{ matrix.os }}";
+        steps = [
+          {
+            name = "Checkout";
+            run = null;
+            uses = "actions/checkout@v2";
+            "with" = {
+              fetch-depth = 0;
+              name = null;
+              signingKey = null;
+              skip_adding_nixpkgs_channel = null;
+            };
+          }
+          {
+            name = "Nix";
+            run = null;
+            uses = "cachix/install-nix-action@v9";
+            "with" = {
+              fetch-depth = null;
+              name = null;
+              signingKey = null;
+              skip_adding_nixpkgs_channel = true;
+            };
+          }
+          {
+            name = "Cachix";
+            run = null;
+            uses = "cachix/cachix-action@v6";
+            "with" = {
+              fetch-depth = null;
+              name = "lorri-test";
+              signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
+              skip_adding_nixpkgs_channel = null;
+            };
+          }
+          { name = "Build"; run = "nix-build"; uses = null; "with" = null; }
+          {
+            name = "Install";
+            run = "nix-env -i ./result";
+            uses = null;
+            "with" = null;
+          }
+          {
+            name = "Self-upgrade";
+            run = "lorri self-upgrade local \$(pwd)";
+            uses = null;
+            "with" = null;
+          }
+        ];
+        strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
+      };
+      nix-build_1909 = {
+        runs-on = "\${{ matrix.os }}";
+        steps = [
+          {
+            name = "Checkout";
+            run = null;
+            uses = "actions/checkout@v2";
+            "with" = null;
+          }
+          {
+            name = "Nix";
+            run = null;
+            uses = "cachix/install-nix-action@v9";
+            "with" = {
+              name = null;
+              signingKey = null;
+              skip_adding_nixpkgs_channel = true;
+            };
+          }
+          {
+            name = "Cachix";
+            run = null;
+            uses = "cachix/cachix-action@v6";
+            "with" = {
+              name = "lorri-test";
+              signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
+              skip_adding_nixpkgs_channel = null;
+            };
+          }
+          {
+            name = "Build";
+            run = "nix-build --arg nixpkgs ./nix/nixpkgs-1909.nix";
+            uses = null;
+            "with" = null;
+          }
+        ];
+        strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
+      };
+      nix-shell = {
+        runs-on = "\${{ matrix.os }}";
+        steps = [
+          {
+            name = "Checkout";
+            run = null;
+            uses = "actions/checkout@v2";
+            "with" = null;
+          }
+          {
+            name = "Nix";
+            run = null;
+            uses = "cachix/install-nix-action@v9";
+            "with" = {
+              name = null;
+              signingKey = null;
+              skip_adding_nixpkgs_channel = true;
+            };
+          }
+          {
+            name = "Cachix";
+            run = null;
+            uses = "cachix/cachix-action@v6";
+            "with" = {
+              name = "lorri-test";
+              signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
+              skip_adding_nixpkgs_channel = null;
+            };
+          }
+          {
+            name = "Build";
+            run = "nix-build -A allBuildInputs shell.nix";
+            uses = null;
+            "with" = null;
+          }
+        ];
+        strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
+      };
+      overlay = {
+        runs-on = "\${{ matrix.os }}";
+        steps = [
+          {
+            name = "Checkout";
+            run = null;
+            uses = "actions/checkout@v2";
+            "with" = null;
+          }
+          {
+            name = "Nix";
+            run = null;
+            uses = "cachix/install-nix-action@v9";
+            "with" = {
+              name = null;
+              signingKey = null;
+              skip_adding_nixpkgs_channel = true;
+            };
+          }
+          {
+            name = "Cachix";
+            run = null;
+            uses = "cachix/cachix-action@v6";
+            "with" = {
+              name = "lorri-test";
+              signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
+              skip_adding_nixpkgs_channel = null;
+            };
+          }
+          {
+            name = "Build w/ overlay (19.09)";
+            run = "nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-1909.json";
+            uses = null;
+            "with" = null;
+          }
+          {
+            name = "Build w/ overlay (stable)";
+            run = "nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-stable.json";
+            uses = null;
+            "with" = null;
+          }
+        ];
+        strategy = { matrix = { os = [ "ubuntu-latest" "macos-latest" ]; }; };
+      };
+    };
+  };
+
+  yaml = pkgs.runCommand "ci.yml" {
+    buildInputs = [ pkgs.yj ];
+    passAsFile = [ "config" ];
+    config = builtins.toJSON config;
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+  }
+    ''
+      yj -jy < $configPath > $out
+    '';
+
+  # writes the file to the right path (toString is the absolute local path)
+  writeConfig = pkgs.writers.writeDash "write-ci.yml" ''
+    cat "${yaml}" > "${toString ./ci.yml}"
+  '';
+in
+writeConfig

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,44 +85,6 @@ jobs:
       run: nix-env -i ./result
     - name: Self-upgrade
       run: lorri self-upgrade local $(pwd)
-  nix-shell-macos-latest:
-    name: nix-shell allBuildInputs (macos-latest)
-    runs-on: macos-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: null
-    - name: Nix
-      uses: cachix/install-nix-action@v9
-      with:
-        skip_adding_nixpkgs_channel: true
-    - name: Cachix
-      uses: cachix/cachix-action@v6
-      with:
-        name: lorri-test
-        signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
-    - name: Build
-      run: nix-build -A allBuildInputs shell.nix
-  nix-shell-ubuntu-latest:
-    name: nix-shell allBuildInputs (ubuntu-latest)
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: null
-    - name: Nix
-      uses: cachix/install-nix-action@v9
-      with:
-        skip_adding_nixpkgs_channel: true
-    - name: Cachix
-      uses: cachix/cachix-action@v6
-      with:
-        name: lorri-test
-        signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
-    - name: Build
-      run: nix-build -A allBuildInputs shell.nix
   overlay-macos-latest:
     name: Overlay builds (macos-latest)
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,20 +183,13 @@ jobs:
         name: lorri-test
         signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
     - name: Cache cargo registry
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-        path: ~/.cargo/registry
-    - name: Cache cargo index
-      uses: actions/cache@v1
-      with:
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-        path: ~/.cargo/git
-    - name: Cache cargo build
-      uses: actions/cache@v1
-      with:
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-        path: target
+        path: |
+          "~/.cargo/registry"
+          "~/.cargo/git"
+          "target"
     - name: CI check
       run: nix-shell --arg isDevelopmentShell false --run 'ci_check'
   rust-ubuntu-latest:
@@ -217,20 +210,13 @@ jobs:
         name: lorri-test
         signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
     - name: Cache cargo registry
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-        path: ~/.cargo/registry
-    - name: Cache cargo index
-      uses: actions/cache@v1
-      with:
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-        path: ~/.cargo/git
-    - name: Cache cargo build
-      uses: actions/cache@v1
-      with:
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-        path: target
+        path: |
+          "~/.cargo/registry"
+          "~/.cargo/git"
+          "target"
     - name: CI check
       run: nix-shell --arg isDevelopmentShell false --run 'ci_check'
 name: CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,8 +197,6 @@ jobs:
       with:
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
         path: target
-    - name: Shell (cache inputs)
-      run: nix-shell
     - name: CI check
       run: nix-shell --arg isDevelopmentShell false --run 'ci_check'
   rust-ubuntu-latest:
@@ -233,8 +231,6 @@ jobs:
       with:
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
         path: target
-    - name: Shell (cache inputs)
-      run: nix-shell
     - name: CI check
       run: nix-shell --arg isDevelopmentShell false --run 'ci_check'
 name: CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 env:
   LORRI_NO_INSTALL_PANIC_HANDLER: absolutely
 jobs:
-  nix-build_1909:
-    runs-on: ${{ matrix.os }}
+  nix-build_1909-macos-latest:
+    name: nix-build [nixos 19.09] (macos-latest)
+    runs-on: macos-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -19,13 +20,28 @@ jobs:
         signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
     - name: Build
       run: nix-build --arg nixpkgs ./nix/nixpkgs-1909.nix
-    strategy:
-      matrix:
-        os:
-        - ubuntu-latest
-        - macos-latest
-  nix-build_stable:
-    runs-on: ${{ matrix.os }}
+  nix-build_1909-ubuntu-latest:
+    name: nix-build [nixos 19.09] (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: null
+    - name: Nix
+      uses: cachix/install-nix-action@v9
+      with:
+        skip_adding_nixpkgs_channel: true
+    - name: Cachix
+      uses: cachix/cachix-action@v6
+      with:
+        name: lorri-test
+        signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+    - name: Build
+      run: nix-build --arg nixpkgs ./nix/nixpkgs-1909.nix
+  nix-build_stable-macos-latest:
+    name: nix-build [nixos stable] (macos-latest)
+    runs-on: macos-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -46,13 +62,32 @@ jobs:
       run: nix-env -i ./result
     - name: Self-upgrade
       run: lorri self-upgrade local $(pwd)
-    strategy:
-      matrix:
-        os:
-        - ubuntu-latest
-        - macos-latest
-  nix-shell:
-    runs-on: ${{ matrix.os }}
+  nix-build_stable-ubuntu-latest:
+    name: nix-build [nixos stable] (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Nix
+      uses: cachix/install-nix-action@v9
+      with:
+        skip_adding_nixpkgs_channel: true
+    - name: Cachix
+      uses: cachix/cachix-action@v6
+      with:
+        name: lorri-test
+        signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+    - name: Build
+      run: nix-build
+    - name: Install
+      run: nix-env -i ./result
+    - name: Self-upgrade
+      run: lorri self-upgrade local $(pwd)
+  nix-shell-macos-latest:
+    name: nix-shell allBuildInputs (macos-latest)
+    runs-on: macos-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -69,13 +104,28 @@ jobs:
         signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
     - name: Build
       run: nix-build -A allBuildInputs shell.nix
-    strategy:
-      matrix:
-        os:
-        - ubuntu-latest
-        - macos-latest
-  overlay:
-    runs-on: ${{ matrix.os }}
+  nix-shell-ubuntu-latest:
+    name: nix-shell allBuildInputs (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: null
+    - name: Nix
+      uses: cachix/install-nix-action@v9
+      with:
+        skip_adding_nixpkgs_channel: true
+    - name: Cachix
+      uses: cachix/cachix-action@v6
+      with:
+        name: lorri-test
+        signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+    - name: Build
+      run: nix-build -A allBuildInputs shell.nix
+  overlay-macos-latest:
+    name: Overlay builds (macos-latest)
+    runs-on: macos-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -94,13 +144,30 @@ jobs:
       run: nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-1909.json
     - name: Build w/ overlay (stable)
       run: nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-stable.json
-    strategy:
-      matrix:
-        os:
-        - ubuntu-latest
-        - macos-latest
-  rust:
-    runs-on: ${{ matrix.os }}
+  overlay-ubuntu-latest:
+    name: Overlay builds (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: null
+    - name: Nix
+      uses: cachix/install-nix-action@v9
+      with:
+        skip_adding_nixpkgs_channel: true
+    - name: Cachix
+      uses: cachix/cachix-action@v6
+      with:
+        name: lorri-test
+        signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+    - name: Build w/ overlay (19.09)
+      run: nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-1909.json
+    - name: Build w/ overlay (stable)
+      run: nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-stable.json
+  rust-macos-latest:
+    name: Rust and ci_check (macos-latest)
+    runs-on: macos-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -134,11 +201,42 @@ jobs:
       run: nix-shell
     - name: CI check
       run: nix-shell --arg isDevelopmentShell false --run 'ci_check'
-    strategy:
-      matrix:
-        os:
-        - ubuntu-latest
-        - macos-latest
+  rust-ubuntu-latest:
+    name: Rust and ci_check (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: null
+    - name: Nix
+      uses: cachix/install-nix-action@v9
+      with:
+        skip_adding_nixpkgs_channel: true
+    - name: Cachix
+      uses: cachix/cachix-action@v6
+      with:
+        name: lorri-test
+        signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+    - name: Cache cargo registry
+      uses: actions/cache@v1
+      with:
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        path: ~/.cargo/registry
+    - name: Cache cargo index
+      uses: actions/cache@v1
+      with:
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        path: ~/.cargo/git
+    - name: Cache cargo build
+      uses: actions/cache@v1
+      with:
+        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+        path: target
+    - name: Shell (cache inputs)
+      run: nix-shell
+    - name: CI check
+      run: nix-shell --arg isDevelopmentShell false --run 'ci_check'
 name: CI
 "on":
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,129 +1,141 @@
-name: CI
-on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "**" ]
 env:
   LORRI_NO_INSTALL_PANIC_HANDLER: absolutely
 jobs:
-  rust:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Nix
-        uses: cachix/install-nix-action@v9
-        with:
-            skip_adding_nixpkgs_channel: true
-      - name: Cachix
-        uses: cachix/cachix-action@v6
-        with:
-            name: lorri-test
-            signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-      - name: Shell (cache inputs)
-        run: nix-shell
-      - name: CI check
-        run: nix-shell --arg isDevelopmentShell false --run 'ci_check'
-  nix-build_stable:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # required for lorri self-upgrade local
-      - name: Nix
-        uses: cachix/install-nix-action@v9
-        with:
-            skip_adding_nixpkgs_channel: true
-      - name: Cachix
-        uses: cachix/cachix-action@v6
-        with:
-            name: lorri-test
-            signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-      - name: Build
-        run: nix-build
-      - name: Install
-        run: nix-env -i ./result
-      - name: Self-upgrade
-        run: lorri self-upgrade local $(pwd)
   nix-build_1909:
     runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Nix
+      uses: cachix/install-nix-action@v9
+      with:
+        skip_adding_nixpkgs_channel: true
+    - name: Cachix
+      uses: cachix/cachix-action@v6
+      with:
+        name: lorri-test
+        signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+    - name: Build
+      run: nix-build --arg nixpkgs ./nix/nixpkgs-1909.nix
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os:
+        - ubuntu-latest
+        - macos-latest
+  nix-build_stable:
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Nix
-        uses: cachix/install-nix-action@v9
-        with:
-            skip_adding_nixpkgs_channel: true
-      - name: Cachix
-        uses: cachix/cachix-action@v6
-        with:
-            name: lorri-test
-            signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-      - name: Build
-        run: nix-build --arg nixpkgs ./nix/nixpkgs-1909.nix
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Nix
+      uses: cachix/install-nix-action@v9
+      with:
+        skip_adding_nixpkgs_channel: true
+    - name: Cachix
+      uses: cachix/cachix-action@v6
+      with:
+        name: lorri-test
+        signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+    - name: Build
+      run: nix-build
+    - name: Install
+      run: nix-env -i ./result
+    - name: Self-upgrade
+      run: lorri self-upgrade local $(pwd)
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        - macos-latest
   nix-shell:
     runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Nix
+      uses: cachix/install-nix-action@v9
+      with:
+        skip_adding_nixpkgs_channel: true
+    - name: Cachix
+      uses: cachix/cachix-action@v6
+      with:
+        name: lorri-test
+        signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+    - name: Build
+      run: nix-build -A allBuildInputs shell.nix
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Nix
-        uses: cachix/install-nix-action@v9
-        with:
-            skip_adding_nixpkgs_channel: true
-      - name: Cachix
-        uses: cachix/cachix-action@v6
-        with:
-            name: lorri-test
-            signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-      - name: Build
-        run: nix-build -A allBuildInputs shell.nix
+        os:
+        - ubuntu-latest
+        - macos-latest
   overlay:
     runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Nix
+      uses: cachix/install-nix-action@v9
+      with:
+        skip_adding_nixpkgs_channel: true
+    - name: Cachix
+      uses: cachix/cachix-action@v6
+      with:
+        name: lorri-test
+        signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+    - name: Build w/ overlay (19.09)
+      run: nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-1909.json
+    - name: Build w/ overlay (stable)
+      run: nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-stable.json
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os:
+        - ubuntu-latest
+        - macos-latest
+  rust:
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Nix
-        uses: cachix/install-nix-action@v9
-        with:
-            skip_adding_nixpkgs_channel: true
-      - name: Cachix
-        uses: cachix/cachix-action@v6
-        with:
-            name: lorri-test
-            signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-      - name: Build w/ overlay (19.09)
-        run: nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-1909.json
-      - name: Build w/ overlay (stable)
-        run: nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-stable.json
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Nix
+      uses: cachix/install-nix-action@v9
+      with:
+        skip_adding_nixpkgs_channel: true
+    - name: Cachix
+      uses: cachix/cachix-action@v6
+      with:
+        name: lorri-test
+        signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+    - name: Cache cargo registry
+      uses: actions/cache@v1
+      with:
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        path: ~/.cargo/registry
+    - name: Cache cargo index
+      uses: actions/cache@v1
+      with:
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        path: ~/.cargo/git
+    - name: Cache cargo build
+      uses: actions/cache@v1
+      with:
+        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+        path: target
+    - name: Shell (cache inputs)
+      run: nix-shell
+    - name: CI check
+      run: nix-shell --arg isDevelopmentShell false --run 'ci_check'
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        - macos-latest
+name: CI
+"on":
+  pull_request:
+    branches:
+    - '**'
+  push:
+    branches:
+    - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: null
     - name: Nix
       uses: cachix/install-nix-action@v9
       with:
@@ -54,6 +56,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: null
     - name: Nix
       uses: cachix/install-nix-action@v9
       with:
@@ -75,6 +79,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: null
     - name: Nix
       uses: cachix/install-nix-action@v9
       with:
@@ -98,6 +104,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: null
     - name: Nix
       uses: cachix/install-nix-action@v9
       with:

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,11 @@
 , pkgs ? import nixpkgs
 }:
 let
-  src = pkgs.nix-gitignore.gitignoreSource [ ".git/" ] ./.;
+  src = pkgs.nix-gitignore.gitignoreSource [
+    ".git/"
+    ".github/"
+    "assets/"
+  ] ./.;
   cargoLorri =
     (
       pkgs.callPackage ./Cargo.nix {

--- a/shell.nix
+++ b/shell.nix
@@ -58,11 +58,6 @@ let
     pkgs.darwin.apple_sdk.frameworks.CoreFoundation
   ];
 
-  # we manually collect all build inputs,
-  # because `mkShell` derivations cannot be built
-  # and we want to cachix them.
-  allBuildInputs = buildInputs;
-
 in
 pkgs.mkShell (
   {
@@ -192,8 +187,6 @@ pkgs.mkShell (
         export NIX_LDFLAGS="-F${pkgs.darwin.apple_sdk.frameworks.CoreFoundation}/Library/Frameworks -framework CoreFoundation $NIX_LDFLAGS"
       ''
     );
-
-    passthru.allBuildInputs = allBuildInputs;
 
     preferLocalBuild = true;
     allowSubstitutes = false;

--- a/shell.nix
+++ b/shell.nix
@@ -101,6 +101,12 @@ pkgs.mkShell (
         ./nix/fmt.sh --check
         nix_fmt=$?
 
+        ${import ./.github/workflows/ci.nix { inherit pkgs; }}
+        ciwrite=$?
+        git diff --quiet -- ./.github/workflows/ci.yml
+        cidiff=$?
+        ciupdate=$((ciwrite + cidiff))
+
         ./nix/update-carnix.sh
         carnixupdate=$?
         git diff --quiet -- Cargo.nix
@@ -120,7 +126,7 @@ pkgs.mkShell (
         echo "cargo fmt: $cargofmtexit"
         echo "cargo clippy: $cargoclippyexit"
 
-        sum=$((manpage + nix_fmt + carnixupdate + cargofmtexit + cargoclippyexit))
+        sum=$((manpage + nix_fmt + ciupdate + carnixupdate + cargofmtexit + cargoclippyexit))
         if [ "$sum" -gt 0 ]; then
           return 1
         fi


### PR DESCRIPTION
This revives the code we used for the travis config, which enabled us
to deduplicate the uncomfortably large amount of CI config. :)

It starts out by converting the config to nix, then refactoring until the gist of the jobs was readable again.

Then it removes some of the build steps, to bring down evaluation time.
Also updates the rust cache action.

cc @cole-h