### PR TITLE
feat(sigterm): daemon exits with 0 on SIGINT or SIGTERM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "directories"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +426,7 @@ version = "1.2.0"
 dependencies = [
  "atomicwrites 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctrlc 3.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-panic 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -506,6 +516,18 @@ dependencies = [
 [[package]]
 name = "nix"
 version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1294,6 +1316,7 @@ dependencies = [
 "checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+"checksum ctrlc 3.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d0b676fa23f995faf587496dcd1c80fead847ed58d2da52ac1caca9a72790dd2"
 "checksum directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "72d337a64190607d4fcca2cb78982c5dd57f4916e19696b48a575fa746b6cb0f"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
@@ -1326,6 +1349,7 @@ dependencies = [
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
+"checksum nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
 "checksum notify 5.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d742ae493f34bd2e20ec2f3c1276fc1981343a8efd7ef12bca4368d0303bed50"
 "checksum num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 "checksum num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -17,6 +17,7 @@ rec {
       dependencies = mapFeatures features ([
         (cratesIO.crates."atomicwrites"."${deps."lorri"."1.2.0"."atomicwrites"}" deps)
         (cratesIO.crates."crossbeam_channel"."${deps."lorri"."1.2.0"."crossbeam_channel"}" deps)
+        (cratesIO.crates."ctrlc"."${deps."lorri"."1.2.0"."ctrlc"}" deps)
         (cratesIO.crates."directories"."${deps."lorri"."1.2.0"."directories"}" deps)
         (cratesIO.crates."human_panic"."${deps."lorri"."1.2.0"."human_panic"}" deps)
         (cratesIO.crates."lazy_static"."${deps."lorri"."1.2.0"."lazy_static"}" deps)
@@ -44,6 +45,10 @@ rec {
     features_.lorri."1.2.0" = deps: f: updateFeatures f (rec {
       atomicwrites."${deps.lorri."1.2.0".atomicwrites}".default = true;
       crossbeam_channel."${deps.lorri."1.2.0".crossbeam_channel}".default = true;
+      ctrlc = fold recursiveUpdate {} [
+        { "${deps.lorri."1.2.0".ctrlc}"."termination" = true; }
+        { "${deps.lorri."1.2.0".ctrlc}".default = true; }
+      ];
       directories."${deps.lorri."1.2.0".directories}".default = true;
       human_panic."${deps.lorri."1.2.0".human_panic}".default = true;
       lazy_static."${deps.lorri."1.2.0".lazy_static}".default = true;
@@ -67,6 +72,7 @@ rec {
     }) [
       (cratesIO.features_.atomicwrites."${deps."lorri"."1.2.0"."atomicwrites"}" deps)
       (cratesIO.features_.crossbeam_channel."${deps."lorri"."1.2.0"."crossbeam_channel"}" deps)
+      (cratesIO.features_.ctrlc."${deps."lorri"."1.2.0"."ctrlc"}" deps)
       (cratesIO.features_.directories."${deps."lorri"."1.2.0"."directories"}" deps)
       (cratesIO.features_.human_panic."${deps."lorri"."1.2.0"."human_panic"}" deps)
       (cratesIO.features_.lazy_static."${deps."lorri"."1.2.0"."lazy_static"}" deps)
@@ -179,6 +185,10 @@ rec {
     lazy_static = "1.4.0";
     autocfg = "1.0.0";
   };
+  deps.ctrlc."3.1.6" = {
+    nix = "0.17.0";
+    winapi = "0.3.8";
+  };
   deps.directories."1.0.2" = {
     libc = "0.2.71";
     winapi = "0.3.8";
@@ -260,6 +270,7 @@ rec {
   deps.lorri."1.2.0" = {
     atomicwrites = "0.2.5";
     crossbeam_channel = "0.3.9";
+    ctrlc = "3.1.6";
     directories = "1.0.2";
     human_panic = "1.0.3";
     lazy_static = "1.4.0";
@@ -314,6 +325,12 @@ rec {
     winapi = "0.3.8";
   };
   deps.nix."0.14.1" = {
+    bitflags = "1.2.1";
+    cfg_if = "0.1.10";
+    libc = "0.2.71";
+    void = "1.0.2";
+  };
+  deps.nix."0.17.0" = {
     bitflags = "1.2.1";
     cfg_if = "0.1.10";
     libc = "0.2.71";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 [dependencies]
 atomicwrites = "0.2.3"
 crossbeam-channel = "0.3.8"
+ctrlc = { version = "3.1.6", features = ["termination"] }
 directories = "1.0.2"
 lazy_static = "1.2.0"
 md5  = "0.6.1"

--- a/nix/carnix/crates-io.nix
+++ b/nix/carnix/crates-io.nix
@@ -974,6 +974,39 @@ rec {
 
 
 # end
+# ctrlc-3.1.6
+
+  crates.ctrlc."3.1.6" = deps: { features?(features_.ctrlc."3.1.6" deps {}) }: buildRustCrate {
+    crateName = "ctrlc";
+    version = "3.1.6";
+    description = "Easy Ctrl-C handler for Rust projects";
+    authors = [ "Antti Keränen <detegr@gmail.com>" ];
+    sha256 = "1680g2jw2r2z3020p1linfjim5jv8ddvapfd3z1083nr557m1bpc";
+    dependencies = (if (kernel == "linux" || kernel == "darwin") then mapFeatures features ([
+      (crates."nix"."${deps."ctrlc"."3.1.6"."nix"}" deps)
+    ]) else [])
+      ++ (if kernel == "windows" then mapFeatures features ([
+      (crates."winapi"."${deps."ctrlc"."3.1.6"."winapi"}" deps)
+    ]) else []);
+    features = mkFeatures (features."ctrlc"."3.1.6" or {});
+  };
+  features_.ctrlc."3.1.6" = deps: f: updateFeatures f (rec {
+    ctrlc."3.1.6".default = (f.ctrlc."3.1.6".default or true);
+    nix."${deps.ctrlc."3.1.6".nix}".default = true;
+    winapi = fold recursiveUpdate {} [
+      { "${deps.ctrlc."3.1.6".winapi}"."consoleapi" = true; }
+      { "${deps.ctrlc."3.1.6".winapi}"."handleapi" = true; }
+      { "${deps.ctrlc."3.1.6".winapi}"."synchapi" = true; }
+      { "${deps.ctrlc."3.1.6".winapi}"."winbase" = true; }
+      { "${deps.ctrlc."3.1.6".winapi}".default = true; }
+    ];
+  }) [
+    (features_.nix."${deps."ctrlc"."3.1.6"."nix"}" deps)
+    (features_.winapi."${deps."ctrlc"."3.1.6"."winapi"}" deps)
+  ];
+
+
+# end
 # directories-1.0.2
 
   crates.directories."1.0.2" = deps: { features?(features_.directories."1.0.2" deps {}) }: buildRustCrate {
@@ -1942,6 +1975,45 @@ rec {
     (features_.cfg_if."${deps."nix"."0.14.1"."cfg_if"}" deps)
     (features_.libc."${deps."nix"."0.14.1"."libc"}" deps)
     (features_.void."${deps."nix"."0.14.1"."void"}" deps)
+  ];
+
+
+# end
+# nix-0.17.0
+
+  crates.nix."0.17.0" = deps: { features?(features_.nix."0.17.0" deps {}) }: buildRustCrate {
+    crateName = "nix";
+    version = "0.17.0";
+    description = "Rust friendly bindings to *nix APIs";
+    authors = [ "The nix-rust Project Developers" ];
+    sha256 = "0zs4ywgv5vnnsp3bhbjs9d3as9z9flnpj914cx8qkgpzcsqcx9aw";
+    dependencies = mapFeatures features ([
+      (crates."bitflags"."${deps."nix"."0.17.0"."bitflags"}" deps)
+      (crates."cfg_if"."${deps."nix"."0.17.0"."cfg_if"}" deps)
+      (crates."libc"."${deps."nix"."0.17.0"."libc"}" deps)
+      (crates."void"."${deps."nix"."0.17.0"."void"}" deps)
+    ])
+      ++ (if kernel == "android" || kernel == "linux" then mapFeatures features ([
+]) else [])
+      ++ (if kernel == "dragonfly" then mapFeatures features ([
+]) else [])
+      ++ (if kernel == "freebsd" then mapFeatures features ([
+]) else []);
+  };
+  features_.nix."0.17.0" = deps: f: updateFeatures f (rec {
+    bitflags."${deps.nix."0.17.0".bitflags}".default = true;
+    cfg_if."${deps.nix."0.17.0".cfg_if}".default = true;
+    libc = fold recursiveUpdate {} [
+      { "${deps.nix."0.17.0".libc}"."extra_traits" = true; }
+      { "${deps.nix."0.17.0".libc}".default = true; }
+    ];
+    nix."0.17.0".default = (f.nix."0.17.0".default or true);
+    void."${deps.nix."0.17.0".void}".default = true;
+  }) [
+    (features_.bitflags."${deps."nix"."0.17.0"."bitflags"}" deps)
+    (features_.cfg_if."${deps."nix"."0.17.0"."cfg_if"}" deps)
+    (features_.libc."${deps."nix"."0.17.0"."libc"}" deps)
+    (features_.void."${deps."nix"."0.17.0"."void"}" deps)
   ];
 
 

--- a/release.nix
+++ b/release.nix
@@ -5,6 +5,13 @@
     # Find the current version number with `git log --pretty=%h | wc -l`
     entries = [
       {
+        version = 676;
+        changes = ''
+          Make `lorri daemon` exit with exit code 0 instead of 130/143 on
+          SIGINT or SIGTERM.
+        '';
+      }
+      {
         version = 655;
         changes = ''
           Add `lorri self-upgrade branch` sub-subcommand.

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,14 @@ fn install_panic_handler() {
     }
 }
 
+// Exit with return code 0 on SIGINT and SIGTERM
+fn install_signal_handler() {
+    ctrlc::set_handler(move || {
+        std::process::exit(0);
+    })
+    .expect("Error setting SIGINT and SIGTERM handler");
+}
+
 /// Try to read `shell.nix` from the current working dir.
 fn get_shell_nix(shellfile: &PathBuf) -> Result<NixFile, ExitError> {
     // use shell.nix from cwd
@@ -105,6 +113,7 @@ fn run_command(log: slog::Logger, opts: Arguments) -> OpResult {
             watch::main(project, opts)
         }
         Command::Daemon(opts) => {
+            install_signal_handler();
             let _guard = without_project();
             daemon::main(opts)
         }


### PR DESCRIPTION
Make the `lorri daemon` subcommand exit with 0 on SIGINT
or SIGTERM.

Other `lorri` subcommands preserve the default SIGINT
and SIGTERM behaviors.

This change is done adds the [ctrlc](https://github.com/Detegr/rust-ctrlc)
crate, by Antti Keränen, as a dependency. This crate provides a simple
and safe interface for handling SIGINT and SIGTERM.

An alternative to the `ctrlc` crate would be to implement the response to the signals
using the the `nix` crate, which is already a lorri dependency.
The downside of this would be adding `unsafe` code to the codebase.

<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/blob/master/CONTRIBUTING.md
-->

<!-- Please replace ISSUE by the issue number this pull request addresses. -->
Closes #463 .

## Overview

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/blob/master/CONTRIBUTING.md for more on how to structure a pull request.
-->
* added the ctrlc crate as a dependency
* added a function that exits with 0 for SIGINT or SIGTERM
* call that function on the Daemon arm of the match statement in `run_command()`

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [ ] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [x] Amended the changelog in `release.nix` (see `release.nix` for instructions)

