### PR TITLE
github remove pr template overview

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,12 @@
 <!--
 If this is the first time you are contributing to lorri, please take a look at:
 https://github.com/nix-community/lorri/blob/master/CONTRIBUTING.md
--->
-## Overview
 
-
-
-<!--
 Explain the approach you took to resolving the issue and provide necessary context.
 There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory and write good commit messages.
 -->
 
-## Checklist
+### Checklist
 
 - [ ] Updated the documentation (code documentation, command help, ...)
 - [ ] Tested the change (unit or integration tests)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,22 @@
 <!--
-Thank you for your contribution!
-
 If this is the first time you are contributing to lorri, please take a look at:
-
-https://github.com/target/lorri/blob/master/CONTRIBUTING.md
+https://github.com/nix-community/lorri/blob/master/CONTRIBUTING.md
 -->
-
-<!-- Please replace ISSUE by the issue number this pull request addresses. -->
-Closes #ISSUE.
-
 ## Overview
+
+
 
 <!--
 Explain the approach you took to resolving the issue and provide necessary context.
-
-There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
-and include good commit messages.
-
-See https://github.com/target/lorri/blob/master/CONTRIBUTING.md for more on how to structure a pull request.
+There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory and write good commit messages.
 -->
 
 ## Checklist
 
-<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
-e.g. bugfixes don't usually require a documentation change. -->
-
 - [ ] Updated the documentation (code documentation, command help, ...)
 - [ ] Tested the change (unit or integration tests)
 - [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)
+
+<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
+e.g. bugfixes don't usually require a documentation change. -->
 


### PR DESCRIPTION
If there is only one commit in a PR, github will automatically add the
commit description before the template, so it doesn’t make sense to
have a special heading.

Also makes the Checklist heading slightly smaller.

<!--
If this is the first time you are contributing to lorri, please take a look at:
https://github.com/nix-community/lorri/blob/master/CONTRIBUTING.md

Explain the approach you took to resolving the issue and provide necessary context.
There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory and write good commit messages.
-->

### Checklist

- [ ] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

