### PR TITLE
Better error msg for flakes

### DIFF
--- a/src/flake-compat-shell.nix
+++ b/src/flake-compat-shell.nix
@@ -1,0 +1,3 @@
+{ system ? builtins.currentSystem }:
+
+(builtins.getFlake (toString ./.)).devShell.${system}


### PR DESCRIPTION
While we don't have native support for flakes yet this PR suggests the workaround suggested in https://github.com/target/lorri/issues/460 if and only if there's no shell.nix and there's a flake.nix found.

I thought about creating the file automatically but I think just suggesting it is nicer.